### PR TITLE
Feat: bottom sheet 컴포넌트

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -75,7 +75,7 @@
     "import/no-duplicates": "error", // merges import statements of the same file. (autofixable, mostly)
 
     // Unused import recommended rules
-    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-imports": "off",
     "unused-imports/no-unused-vars": [
       "warn",
       { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" }

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,9 @@
 const nextConfig = {
   reactStrictMode: false,
   swcMinify: true,
+  compiler: {
+    styledComponents: true,
+  },
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/node": "18.8.3",
     "@types/react": "18.0.21",
     "@types/react-dom": "18.0.6",
+    "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.40.0",
     "@typescript-eslint/parser": "^5.40.0",
     "@yarnpkg/sdks": "^3.0.0-rc.25",

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -7,18 +7,18 @@ import Portal from './Portal';
 export interface BottomSheetProps {
   isShowing: boolean;
   children: ReactNode;
-  handleClose: VoidFunction;
+  onClose: VoidFunction;
 }
 
-export default function BottomSheet({ isShowing, children, handleClose }: BottomSheetProps) {
-  const onDeleteHandler = (e: React.MouseEvent<HTMLDivElement>) => {
+export default function BottomSheet({ isShowing, children, onClose }: BottomSheetProps) {
+  const handleDelete = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target !== e.currentTarget) return;
-    handleClose();
+    onClose();
   };
 
   return (
     <Portal isShowing={isShowing}>
-      <DimmedBackdrop onClick={onDeleteHandler}>
+      <DimmedBackdrop onClick={handleDelete}>
         <ContentWrapper>{children}</ContentWrapper>
       </DimmedBackdrop>
     </Portal>

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -1,29 +1,31 @@
 import type { ReactNode } from 'react';
 import React from 'react';
-import { css } from 'styled-components';
+import styled from 'styled-components';
 
 import Portal from './Portal';
 
 export interface BottomSheetProps {
   isShowing: boolean;
   children: ReactNode;
-  onClose: VoidFunction;
+  handleClose: VoidFunction;
 }
 
-export default function BottomSheet({ isShowing, children, onClose }: BottomSheetProps) {
+export default function BottomSheet({ isShowing, children, handleClose }: BottomSheetProps) {
   const onDeleteHandler = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target !== e.currentTarget) return;
-    onClose();
+    handleClose();
   };
 
   return (
     <Portal isShowing={isShowing}>
-      <div className="transition-all">{children}</div>
+      <DimmedBackdrop onClick={onDeleteHandler}>
+        <CotentWrapper>{children}</CotentWrapper>
+      </DimmedBackdrop>
     </Portal>
   );
 }
 
-const dimBackdropCss = () => css`
+const DimmedBackdrop = styled.div`
   position: fixed;
   z-index: 10000;
   top: 0;
@@ -38,7 +40,8 @@ const dimBackdropCss = () => css`
 `;
 
 const HIGHT = 190;
-const contentWrapperCss = () => css`
+
+const CotentWrapper = styled.div`
   position: absolute;
   top: 100%;
   transform: translateY(-100%);
@@ -47,13 +50,14 @@ const contentWrapperCss = () => css`
   width: 100%;
   height: ${HIGHT}px;
 
-  background-color: ${colors.gray9};
-  border-radius: ${radius.lg} ${radius.lg} 0 0;
-
+  background-color: pink;
+  border-radius: 1rem 1rem 0 0;
   overflow-y: scroll;
 `;
 
-export const bottomSheetVariants: Variants = {
+const defaultEasing = [0.6, -0.05, 0.01, 0.99];
+
+const bottomSheetVariants = {
   initial: {
     y: 0,
     transition: { duration: 0.6, ease: defaultEasing },

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -35,11 +35,8 @@ const DimmedBackdrop = styled.div`
   height: 100%;
 
   background-color: rgba(0, 0, 0, 0.6);
-
   overflow: hidden;
 `;
-
-const HIGHT = 190;
 
 const CotentWrapper = styled.div`
   position: absolute;
@@ -48,29 +45,29 @@ const CotentWrapper = styled.div`
   z-index: 1000;
 
   width: 100%;
-  height: ${HIGHT}px;
 
-  background-color: pink;
+  background-color: white;
   border-radius: 1rem 1rem 0 0;
-  overflow-y: scroll;
+  overflow-y: auto;
 `;
 
-const defaultEasing = [0.6, -0.05, 0.01, 0.99];
+// MEMO: framer에서 사용되던 tranmsition 값
+// const defaultEasing = [0.6, -0.05, 0.01, 0.99];
 
-const bottomSheetVariants = {
-  initial: {
-    y: 0,
-    transition: { duration: 0.6, ease: defaultEasing },
-    willChange: 'transform',
-  },
-  animate: {
-    y: '-100%',
-    transition: { duration: 0.6, ease: defaultEasing },
-    willChange: 'transform',
-  },
-  exit: {
-    y: 0,
-    transition: { duration: 0.6, ease: defaultEasing },
-    willChange: 'transform',
-  },
-};
+// const bottomSheetVariants = {
+//   initial: {
+//     y: 0,
+//     transition: { duration: 0.6, ease: defaultEasing },
+//     willChange: 'transform',
+//   },
+//   animate: {
+//     y: '-100%',
+//     transition: { duration: 0.6, ease: defaultEasing },
+//     willChange: 'transform',
+//   },
+//   exit: {
+//     y: 0,
+//     transition: { duration: 0.6, ease: defaultEasing },
+//     willChange: 'transform',
+//   },
+// };

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -38,6 +38,7 @@ const DimmedBackdrop = styled.div`
   overflow: hidden;
 `;
 
+// TODO: transition 추가
 const CotentWrapper = styled.div`
   position: absolute;
   top: 100%;

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from 'react';
+import React from 'react';
+import { css } from 'styled-components';
+
+import Portal from './Portal';
+
+export interface BottomSheetProps {
+  isShowing: boolean;
+  children: ReactNode;
+  onClose: VoidFunction;
+}
+
+export default function BottomSheet({ isShowing, children, onClose }: BottomSheetProps) {
+  const onDeleteHandler = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) return;
+    onClose();
+  };
+
+  return (
+    <Portal isShowing={isShowing}>
+      <div className="transition-all">{children}</div>
+    </Portal>
+  );
+}
+
+const dimBackdropCss = () => css`
+  position: fixed;
+  z-index: 10000;
+  top: 0;
+  left: 0;
+
+  width: 100vw;
+  height: 100%;
+
+  background-color: rgba(0, 0, 0, 0.6);
+
+  overflow: hidden;
+`;
+
+const HIGHT = 190;
+const contentWrapperCss = () => css`
+  position: absolute;
+  top: 100%;
+  transform: translateY(-100%);
+  z-index: 1000;
+
+  width: 100%;
+  height: ${HIGHT}px;
+
+  background-color: ${colors.gray9};
+  border-radius: ${radius.lg} ${radius.lg} 0 0;
+
+  overflow-y: scroll;
+`;
+
+export const bottomSheetVariants: Variants = {
+  initial: {
+    y: 0,
+    transition: { duration: 0.6, ease: defaultEasing },
+    willChange: 'transform',
+  },
+  animate: {
+    y: '-100%',
+    transition: { duration: 0.6, ease: defaultEasing },
+    willChange: 'transform',
+  },
+  exit: {
+    y: 0,
+    transition: { duration: 0.6, ease: defaultEasing },
+    willChange: 'transform',
+  },
+};

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -19,7 +19,7 @@ export default function BottomSheet({ isShowing, children, handleClose }: Bottom
   return (
     <Portal isShowing={isShowing}>
       <DimmedBackdrop onClick={onDeleteHandler}>
-        <CotentWrapper>{children}</CotentWrapper>
+        <ContentWrapper>{children}</ContentWrapper>
       </DimmedBackdrop>
     </Portal>
   );
@@ -30,7 +30,6 @@ const DimmedBackdrop = styled.div`
   z-index: 10000;
   top: 0;
   left: 0;
-
   width: 100vw;
   height: 100%;
 
@@ -39,12 +38,11 @@ const DimmedBackdrop = styled.div`
 `;
 
 // TODO: transition 추가
-const CotentWrapper = styled.div`
+const ContentWrapper = styled.div`
   position: absolute;
   top: 100%;
   transform: translateY(-100%);
   z-index: 1000;
-
   width: 100%;
 
   background-color: white;

--- a/src/components/common/BottomSheetOptions.tsx
+++ b/src/components/common/BottomSheetOptions.tsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+interface Option {
+  id: number;
+  label: string;
+}
+
+const BottomSheetOptions = ({ list }: { list: Option[] }) => {
+  return (
+    <OptionList>
+      {list.map((item) => (
+        <OptionItem key={item.id}>{item.label}</OptionItem>
+      ))}
+    </OptionList>
+  );
+};
+
+export default BottomSheetOptions;
+
+const OptionList = styled.ul`
+  margin-bottom: 2rem;
+`;
+
+const OptionItem = styled.li`
+  padding: 1.2rem 3rem;
+  border-bottom: 0.1rem solid blue;
+`;

--- a/src/components/common/BottomSheetOptions.tsx
+++ b/src/components/common/BottomSheetOptions.tsx
@@ -18,10 +18,10 @@ const BottomSheetOptions = ({ list }: { list: Option[] }) => {
 export default BottomSheetOptions;
 
 const OptionList = styled.ul`
-  margin-bottom: 2rem;
+  margin-bottom: 5rem;
 `;
 
 const OptionItem = styled.li`
   padding: 1.2rem 3rem;
-  border-bottom: 0.1rem solid blue;
+  border-bottom: 0.1rem solid #f0f0f0;
 `;

--- a/src/components/common/Button.stories.tsx
+++ b/src/components/common/Button.stories.tsx
@@ -30,7 +30,7 @@ Primary.args = {
   position: 'right',
   children: 'Sample Button',
   disabled: true,
-  clickHandler: mockClickHandler,
+  onClick: mockClickHandler,
 };
 
 export const Secondary = Template.bind({});
@@ -42,5 +42,5 @@ Secondary.args = {
   position: 'right',
   children: 'Sample Button',
   disabled: true,
-  clickHandler: mockClickHandler,
+  onClick: mockClickHandler,
 };

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -8,7 +8,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   iconName?: string;
   position?: string;
   disabled?: boolean;
-  clickHandler: () => void;
+  onClick: () => void;
 }
 
 const Button = ({
@@ -18,7 +18,7 @@ const Button = ({
   position = 'right',
   children,
   disabled = false,
-  clickHandler,
+  onClick,
 }: PropsWithChildren<ButtonProps>) => {
   // TODO: storybook 내에서 svg import 가 안되는 이슈 발생하여 해결중
   // const DynamicIcon = dynamic(() => import(`../../../public/icons/${iconName}.svg`));
@@ -27,20 +27,12 @@ const Button = ({
   return (
     <div className="flex">
       {position === 'right' ? (
-        <button
-          className={`btn-${buttonStyle.toLowerCase()} ${defaultClass}`}
-          onClick={clickHandler}
-          disabled={disabled}
-        >
+        <button className={`btn-${buttonStyle.toLowerCase()} ${defaultClass}`} onClick={onClick} disabled={disabled}>
           {children}
           {/* {hasIcon && <DynamicIcon />} */}
         </button>
       ) : (
-        <button
-          className={`btn-${buttonStyle.toLowerCase()} ${defaultClass}`}
-          onClick={clickHandler}
-          disabled={disabled}
-        >
+        <button className={`btn-${buttonStyle.toLowerCase()} ${defaultClass}`} onClick={onClick} disabled={disabled}>
           {/* {hasIcon && <DynamicIcon />} */}
           {children}
         </button>

--- a/src/components/common/Portal.tsx
+++ b/src/components/common/Portal.tsx
@@ -1,0 +1,12 @@
+import type { PropsWithChildren } from 'react';
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  isShowing: boolean;
+}
+
+export default function Portal({ children, isShowing }: PropsWithChildren<PortalProps>) {
+  const container = typeof window !== 'undefined' && document.body;
+
+  return container ? createPortal(<div>{isShowing && children}</div>, container) : <></>;
+}

--- a/src/components/common/Portal.tsx
+++ b/src/components/common/Portal.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from 'react';
+import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 interface PortalProps {
@@ -6,7 +7,18 @@ interface PortalProps {
 }
 
 export default function Portal({ children, isShowing }: PropsWithChildren<PortalProps>) {
-  const container = typeof window !== 'undefined' && document.body;
+  const [isMounted, setIsMounted] = useState(false);
+  const [container, setContainer] = useState<Element | null>(null);
 
-  return container ? createPortal(<div>{isShowing && children}</div>, container) : <></>;
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    const containerDOM = document.getElementById('portal');
+    setContainer(containerDOM);
+  }, [isMounted]);
+
+  if (!isMounted || !container) return <></>;
+  return createPortal(<div>{isShowing && children}</div>, container);
 }

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -1,0 +1,12 @@
+import { useRecoilState } from 'recoil';
+
+import { bottomSheetOpenState } from '@/store/bottomSheet';
+
+export function useBottomSheet() {
+  const [isShowing, setIsShowing] = useRecoilState(bottomSheetOpenState);
+
+  return {
+    isShowing,
+    setIsShowing,
+  };
+}

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -1,9 +1,9 @@
 import { useRecoilState } from 'recoil';
 
-import { bottomSheetOpenState } from '@/store/bottomSheet';
+import { bottomSheetAtom } from '@/store/components';
 
 export function useBottomSheet() {
-  const [isShowing, setIsShowing] = useRecoilState(bottomSheetOpenState);
+  const [isShowing, setIsShowing] = useRecoilState(bottomSheetAtom);
 
   return {
     isShowing,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,11 +8,12 @@ function MyApp({ Component, pageProps }: AppProps) {
   const queryClient = new QueryClient();
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <RecoilRoot>
-        <Component {...pageProps} />;
-      </RecoilRoot>
-    </QueryClientProvider>
+    <RecoilRoot>
+      <QueryClientProvider client={queryClient}>
+        <div id="portal" />
+        <Component {...pageProps} />
+      </QueryClientProvider>
+    </RecoilRoot>
   );
 }
 

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -1,17 +1,22 @@
 import styled from 'styled-components';
 
 import BottomSheet from '@/components/common/BottomSheet';
+import BottomSheetOptions from '@/components/common/BottomSheetOptions';
 import { useBottomSheet } from '@/hooks/useBottomSheet';
 
 const Playground = () => {
   const { isShowing, setIsShowing } = useBottomSheet();
 
+  const mockList = [
+    { id: 1, label: '하하' },
+    { id: 2, label: '호호' },
+    { id: 2, label: '후후' },
+  ];
+
   return (
     <div>
       <BottomSheet isShowing={isShowing} handleClose={() => setIsShowing(false)}>
-        <OptionList>
-          <OptionItem>얍얍</OptionItem>
-        </OptionList>
+        <BottomSheetOptions list={mockList} />
       </BottomSheet>
       <TestButton onClick={() => setIsShowing(true)}>바텀시트 열기</TestButton>
     </div>
@@ -23,14 +28,6 @@ export default Playground;
 const TestButton = styled.button`
   background-color: black;
   color: white;
-  height: 2rem;
-`;
-
-const OptionList = styled.ul`
-  margin-bottom: 2rem;
-`;
-
-const OptionItem = styled.li`
-  padding: 1.2rem 3rem;
-  border-bottom: 0.1rem solid blue;
+  width: 10rem;
+  height: 5rem;
 `;

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -15,7 +15,7 @@ const Playground = () => {
 
   return (
     <div>
-      <BottomSheet isShowing={isShowing} handleClose={() => setIsShowing(false)}>
+      <BottomSheet isShowing={isShowing} onClose={() => setIsShowing(false)}>
         <BottomSheetOptions list={mockList} />
       </BottomSheet>
       <TestButton onClick={() => setIsShowing(true)}>바텀시트 열기</TestButton>

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+import BottomSheet from '@/components/common/BottomSheet';
+import { useBottomSheet } from '@/hooks/useBottomSheet';
+
+const Playground = () => {
+  const { isShowing, setIsShowing } = useBottomSheet();
+
+  return (
+    <div>
+      <BottomSheet isShowing={isShowing} handleClose={() => setIsShowing(false)}>
+        라라라
+      </BottomSheet>
+      <TestButton onClick={() => setIsShowing(true)}>바텀시트 열기</TestButton>
+    </div>
+  );
+};
+
+export default Playground;
+
+const TestButton = styled.button`
+  background-color: black;
+  color: white;
+  height: 2rem;
+`;

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -9,7 +9,9 @@ const Playground = () => {
   return (
     <div>
       <BottomSheet isShowing={isShowing} handleClose={() => setIsShowing(false)}>
-        라라라
+        <OptionList>
+          <OptionItem>얍얍</OptionItem>
+        </OptionList>
       </BottomSheet>
       <TestButton onClick={() => setIsShowing(true)}>바텀시트 열기</TestButton>
     </div>
@@ -22,4 +24,13 @@ const TestButton = styled.button`
   background-color: black;
   color: white;
   height: 2rem;
+`;
+
+const OptionList = styled.ul`
+  margin-bottom: 2rem;
+`;
+
+const OptionItem = styled.li`
+  padding: 1.2rem 3rem;
+  border-bottom: 0.1rem solid blue;
 `;

--- a/src/store/bottomSheet.ts
+++ b/src/store/bottomSheet.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const bottomSheetOpenState = atom({
+  key: 'BottomSheet',
+  default: false,
+});

--- a/src/store/bottomSheet.ts
+++ b/src/store/bottomSheet.ts
@@ -1,6 +1,0 @@
-import { atom } from 'recoil';
-
-export const bottomSheetOpenState = atom({
-  key: 'BottomSheet',
-  default: false,
-});

--- a/src/store/components/atoms.ts
+++ b/src/store/components/atoms.ts
@@ -3,11 +3,16 @@ import { atom } from 'recoil';
 import type { TabProps } from './types';
 
 const tabAtom = atom<TabProps>({
-  key: 'tabAtom',
+  key: 'tab',
   default: {
     id: '',
     content: '',
   },
 });
 
-export { tabAtom };
+const bottomSheetAtom = atom({
+  key: 'bottomSheet',
+  default: false,
+});
+
+export { bottomSheetAtom, tabAtom };

--- a/src/store/components/index.ts
+++ b/src/store/components/index.ts
@@ -1,0 +1,1 @@
+export * from './atoms';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2877,6 +2877,14 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/hoist-non-react-statics@*":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz#693b316ad323ea97eed6b38ed1a3cc02b1672b57"
@@ -3064,6 +3072,15 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/styled-components@^5.1.26":
+  version "5.1.26"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.26.tgz#5627e6812ee96d755028a98dae61d28e57c233af"
+  integrity sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==
+  dependencies:
+    "@types/hoist-non-react-statics" "*"
+    "@types/react" "*"
+    csstype "^3.0.2"
 
 "@types/tapable@^1", "@types/tapable@^1.0.5":
   version "1.0.8"
@@ -7655,7 +7672,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==


### PR DESCRIPTION
## What's Changed? 
### Portal 컴포넌트 추가
- Portal 을 사용해서, Bottomsheet 컴포넌트가 열리게 합니다. 
- 이후 popup 컴포넌트에도 사용할 수 있을것 같습니다.
- Portal 컴포넌트로 감싸고, isShowing boolean 값으로 컨트롤합니다.

```
<Portal isShowing={isShowing}>
      <ChildrenComponent />
</Portal>
```

### bottom sheet 바텀시트 컴포넌트 추가 
- bottom sheet 바텀시트 컴포넌트 추가
- bottomsheet 내부에 들어가는 optionlist 컴포넌트 추가

### 설정 변경
- styled-components 를 사용 시에 next dev 의 HMR 정상 동작하지 않는 이슈가 있어서 next.config.js 수정

## Screenshots
<img width="486" alt="Screen Shot 2022-11-20 at 11 17 37 PM" src="https://user-images.githubusercontent.com/46391618/202907283-7034f265-f1d0-49a6-9742-332e7fe8490a.png">

## Related to any issues?
- ⛔️

## Dependency Changes
```
"@types/styled-components": "^5.1.26",
```

## Test Code
- ⛔️
