### PR TITLE
Feat: radio button 

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -1,1 +1,2 @@
 declare module '*.svg';
+declare module 'styled-components';

--- a/src/components/common/RadioGroup.tsx
+++ b/src/components/common/RadioGroup.tsx
@@ -3,32 +3,30 @@ import { uniqueId } from 'src/lib/utils';
 import styled from 'styled-components';
 
 import { colors } from '@/constants/styles';
+import { Radio } from '@/hooks/useRadioGroup';
 
 interface RadioGroupProps {
-  currentSelected: string;
-  name?: string;
-  list: string[];
+  currentSelected: Radio | null;
+  list: Radio[];
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  name?: string;
 }
 
-const RadioGroup = ({ currentSelected, name = 'radio', list, onChange }: RadioGroupProps) => {
+const RadioGroup = ({ currentSelected, list, onChange, name = 'radio' }: RadioGroupProps) => {
   return (
     <>
-      {list.map((label) => (
-        <Radio key={uniqueId('radio')}>
-          <input
-            type="radio"
-            id={label}
-            name={name}
-            value={label}
-            checked={currentSelected === label}
-            onChange={onChange}
-          />
-          <label htmlFor={label}>
-            <span className="text-b2">{label}</span>
-          </label>
-        </Radio>
-      ))}
+      {list.map((item) => {
+        const isSelected = currentSelected?.label === item.label;
+
+        return (
+          <Radio key={uniqueId('radio')}>
+            <label htmlFor={item.label} className={isSelected ? 'selected' : ''}>
+              <input type="radio" id={item.key} name={name} value={item.label} onChange={onChange} />
+              <span className="text-b2">{item.label}</span>
+            </label>
+          </Radio>
+        );
+      })}
     </>
   );
 };
@@ -43,6 +41,15 @@ const Radio = styled.div`
     align-items: center;
     position: relative;
 
+    span {
+      margin-left: 1rem;
+    }
+
+    input[type='radio'] {
+      position: fixed;
+      opacity: 0;
+    }
+
     &::before {
       box-sizing: border-box;
       display: inline-block;
@@ -53,31 +60,20 @@ const Radio = styled.div`
       border-radius: 50%;
       background-color: white;
     }
-  }
 
-  span {
-    margin-left: 1rem;
-  }
+    &.selected::before {
+      border: 0.1rem solid black;
+    }
 
-  input[type='radio'] {
-    position: fixed;
-    opacity: 0;
-
-    &:checked ~ label {
-      &::before {
-        border: 0.1rem solid black;
-      }
-
-      &::after {
-        z-index: 10;
-        position: absolute;
-        left: 0.4rem;
-        content: '';
-        width: 1.2rem;
-        height: 1.2rem;
-        border-radius: 50%;
-        background-color: black;
-      }
+    &.selected::after {
+      z-index: 10;
+      position: absolute;
+      left: 0.4rem;
+      content: '';
+      width: 1.2rem;
+      height: 1.2rem;
+      border-radius: 50%;
+      background-color: black;
     }
   }
 `;

--- a/src/components/common/RadioGroup.tsx
+++ b/src/components/common/RadioGroup.tsx
@@ -1,0 +1,83 @@
+import type { ChangeEvent } from 'react';
+import { uniqueId } from 'src/lib/utils';
+import styled from 'styled-components';
+
+import { colors } from '@/constants/styles';
+
+interface RadioGroupProps {
+  currentSelected: string;
+  name?: string;
+  list: string[];
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+}
+
+const RadioGroup = ({ currentSelected, name = 'radio', list, onChange }: RadioGroupProps) => {
+  return (
+    <>
+      {list.map((label) => (
+        <Radio key={uniqueId('radio')}>
+          <input
+            type="radio"
+            id={label}
+            name={name}
+            value={label}
+            checked={currentSelected === label}
+            onChange={onChange}
+          />
+          <label htmlFor={label}>
+            <span className="text-b2">{label}</span>
+          </label>
+        </Radio>
+      ))}
+    </>
+  );
+};
+
+export default RadioGroup;
+
+const Radio = styled.div`
+  margin-bottom: 1.5rem;
+
+  label {
+    display: flex;
+    align-items: center;
+    position: relative;
+
+    &::before {
+      box-sizing: border-box;
+      display: inline-block;
+      content: '';
+      width: 2rem;
+      height: 2rem;
+      border: 0.1rem solid ${colors.gray200};
+      border-radius: 50%;
+      background-color: white;
+    }
+  }
+
+  span {
+    margin-left: 1rem;
+  }
+
+  input[type='radio'] {
+    position: fixed;
+    opacity: 0;
+
+    &:checked ~ label {
+      &::before {
+        border: 0.1rem solid black;
+      }
+
+      &::after {
+        z-index: 10;
+        position: absolute;
+        left: 0.4rem;
+        content: '';
+        width: 1.2rem;
+        height: 1.2rem;
+        border-radius: 50%;
+        background-color: black;
+      }
+    }
+  }
+`;

--- a/src/components/common/RadioGroup.tsx
+++ b/src/components/common/RadioGroup.tsx
@@ -20,7 +20,7 @@ const RadioGroup = ({ currentSelected, list, onChange, name = 'radio' }: RadioGr
 
         return (
           <Radio key={uniqueId('radio')}>
-            <label htmlFor={item.label} className={isSelected ? 'selected' : ''}>
+            <label htmlFor={item.key} className={isSelected ? 'selected' : ''}>
               <input type="radio" id={item.key} name={name} value={item.label} onChange={onChange} />
               <span className="text-b2">{item.label}</span>
             </label>

--- a/src/constants/styles/index.ts
+++ b/src/constants/styles/index.ts
@@ -1,0 +1,17 @@
+const colors = {
+  gray100: '#F3F3F3',
+  gray200: '#E7E7E7',
+  gray300: '#CFCFCF',
+  gray400: '#A0A0A0',
+  gray500: '#585858',
+  gray600: '#111111',
+  primaryRed: '#FB6C6C',
+  primaryError: '#F84848',
+  primaryBlue: '#4D77FF',
+  primaryDark: '#27292F',
+  bgGray: '#FAFAFA',
+  bgRed: '#FFF0F0',
+  bgBlue: '#EDF1FF',
+};
+
+export { colors };

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -2,11 +2,13 @@ import { useRecoilState } from 'recoil';
 
 import { bottomSheetAtom } from '@/store/components';
 
-export function useBottomSheet() {
+const useBottomSheet = () => {
   const [isShowing, setIsShowing] = useRecoilState(bottomSheetAtom);
 
   return {
     isShowing,
     setIsShowing,
   };
-}
+};
+
+export default useBottomSheet;

--- a/src/hooks/useRadioGroup.ts
+++ b/src/hooks/useRadioGroup.ts
@@ -1,11 +1,19 @@
 import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 
-const useRadioGroup = (list: string[]) => {
-  const [currentSelected, setCurrentSelected] = useState<string>('');
+export interface Radio {
+  key: string;
+  label: string;
+}
+
+const useRadioGroup = (list: Radio[]) => {
+  const [currentSelected, setCurrentSelected] = useState<Radio | null>(null);
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setCurrentSelected(e.target.value);
+    setCurrentSelected(() => ({
+      key: e.target.id,
+      label: e.target.value,
+    }));
   };
 
   return {

--- a/src/hooks/useRadioGroup.ts
+++ b/src/hooks/useRadioGroup.ts
@@ -2,7 +2,6 @@ import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 
 const useRadioGroup = (list: string[]) => {
-  const [labelList, setLabelList] = useState<string[]>(list);
   const [currentSelected, setCurrentSelected] = useState<string>('');
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -10,7 +9,7 @@ const useRadioGroup = (list: string[]) => {
   };
 
   return {
-    labelList,
+    list,
     currentSelected,
     onChange,
   };

--- a/src/hooks/useRadioGroup.ts
+++ b/src/hooks/useRadioGroup.ts
@@ -1,0 +1,19 @@
+import type { ChangeEvent } from 'react';
+import { useState } from 'react';
+
+const useRadioGroup = (list: string[]) => {
+  const [labelList, setLabelList] = useState<string[]>(list);
+  const [currentSelected, setCurrentSelected] = useState<string>('');
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setCurrentSelected(e.target.value);
+  };
+
+  return {
+    labelList,
+    currentSelected,
+    onChange,
+  };
+};
+
+export default useRadioGroup;

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -15,7 +15,7 @@ const Playground = () => {
     { id: 2, label: '후후' },
   ];
 
-  const { labelList, currentSelected, onChange } = useRadioGroup([
+  const { list, currentSelected, onChange } = useRadioGroup([
     '사용자 정보가 부정확해요.',
     '광고성/홍보성 글이에요.',
     'text3',
@@ -33,7 +33,7 @@ const Playground = () => {
       </PlaygroundBlock>
       <PlaygroundBlock>
         <PlaygroundTitle>Radio (Group)</PlaygroundTitle>
-        <RadioGroup list={labelList} currentSelected={currentSelected} onChange={onChange} />
+        <RadioGroup list={list} currentSelected={currentSelected} onChange={onChange} />
       </PlaygroundBlock>
     </PlaygroundContainer>
   );

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -2,7 +2,9 @@ import styled from 'styled-components';
 
 import BottomSheet from '@/components/common/BottomSheet';
 import BottomSheetOptions from '@/components/common/BottomSheetOptions';
+import RadioGroup from '@/components/common/RadioGroup';
 import { useBottomSheet } from '@/hooks/useBottomSheet';
+import useRadioGroup from '@/hooks/useRadioGroup';
 
 const Playground = () => {
   const { isShowing, setIsShowing } = useBottomSheet();
@@ -13,13 +15,27 @@ const Playground = () => {
     { id: 2, label: '후후' },
   ];
 
+  const { labelList, currentSelected, onChange } = useRadioGroup([
+    '사용자 정보가 부정확해요.',
+    '광고성/홍보성 글이에요.',
+    'text3',
+    'text4',
+  ]);
+
   return (
-    <div>
-      <BottomSheet isShowing={isShowing} onClose={() => setIsShowing(false)}>
-        <BottomSheetOptions list={mockList} />
-      </BottomSheet>
-      <TestButton onClick={() => setIsShowing(true)}>바텀시트 열기</TestButton>
-    </div>
+    <PlaygroundContainer>
+      <PlaygroundBlock>
+        <PlaygroundTitle>Bottom Sheet</PlaygroundTitle>
+        <BottomSheet isShowing={isShowing} onClose={() => setIsShowing(false)}>
+          <BottomSheetOptions list={mockList} />
+        </BottomSheet>
+        <TestButton onClick={() => setIsShowing(true)}>바텀시트 열기</TestButton>
+      </PlaygroundBlock>
+      <PlaygroundBlock>
+        <PlaygroundTitle>Radio (Group)</PlaygroundTitle>
+        <RadioGroup list={labelList} currentSelected={currentSelected} onChange={onChange} />
+      </PlaygroundBlock>
+    </PlaygroundContainer>
   );
 };
 
@@ -30,4 +46,19 @@ const TestButton = styled.button`
   color: white;
   width: 10rem;
   height: 5rem;
+`;
+
+const PlaygroundContainer = styled.div`
+  padding: 3rem;
+`;
+
+const PlaygroundBlock = styled.div`
+  background-color: #eee;
+  margin-bottom: 2rem;
+  padding: 4rem;
+`;
+
+const PlaygroundTitle = styled.h3`
+  font-size: 2rem;
+  margin-bottom: 2rem;
 `;

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import BottomSheet from '@/components/common/BottomSheet';
 import BottomSheetOptions from '@/components/common/BottomSheetOptions';
 import RadioGroup from '@/components/common/RadioGroup';
-import { useBottomSheet } from '@/hooks/useBottomSheet';
+import useBottomSheet from '@/hooks/useBottomSheet';
 import useRadioGroup from '@/hooks/useRadioGroup';
 
 const Playground = () => {

--- a/src/pages/playground.tsx
+++ b/src/pages/playground.tsx
@@ -16,10 +16,18 @@ const Playground = () => {
   ];
 
   const { list, currentSelected, onChange } = useRadioGroup([
-    '사용자 정보가 부정확해요.',
-    '광고성/홍보성 글이에요.',
-    'text3',
-    'text4',
+    {
+      key: 'INCORRECT',
+      label: '사용자 정보가 부정확해요.',
+    },
+    {
+      key: 'MARKETING',
+      label: '광고성/홍보성 글이에요.',
+    },
+    {
+      key: 'DUPLICATED',
+      label: '이 게시글이 도배 되어있어요.',
+    },
   ]);
 
   return (


### PR DESCRIPTION
## What's Changed? 
### RadioGroup 컴포넌트, useRadioGroup 훅  추가
사용 시 useRadioButton 을 다음과 같이 사용해서 컴포넌트에 연결합니다.

```
 const { list, currentSelected, onChange } = useRadioGroup([
    {
      key: 'INCORRECT',
      label: '사용자 정보가 부정확해요.',
    },
    {
      key: 'MARKETING',
      label: '광고성/홍보성 글이에요.',
    },
    {
      key: 'DUPLICATED',
      label: '이 게시글이 도배 되어있어요.',
    },
  ]);

<RadioGroup list={list} currentSelected={currentSelected} onChange={onChange} />
```

list: 라디오 버튼에 들어가는 key, label로 이루어진 리스트
currentSelected: 선택된 라디오 값 

이후 DB에 저장할때 key값이 사용될것 같아 라벨에 해당하는 key를 따로 가지고있는 형태로 작업하였습니다.

### styled components module, 변수 등 추가
- tailwind 사용하면서 작업 속도가 너무 안나서 ㅠㅠ styled-components 사용하였습니다.

## Screenshots
<img width="759" alt="Screen Shot 2022-12-04 at 7 21 06 PM" src="https://user-images.githubusercontent.com/46391618/205485901-fdb24b94-f9a8-438b-be65-40d0437a21a8.png">

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
