### PR TITLE
feat: talent select input

### DIFF
--- a/src/components/common/SelectInput.stories.tsx
+++ b/src/components/common/SelectInput.stories.tsx
@@ -1,0 +1,23 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import SelectInput from './SelectInput';
+
+export default {
+  title: 'Commons/SelectInput',
+  component: SelectInput,
+} as ComponentMeta<typeof SelectInput>;
+
+const Template: ComponentStory<typeof SelectInput> = (args) => (
+  <SelectInput {...args} href="talent/register/category" />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  placeholder: '카테고리를 선택해 주세요.',
+};
+
+export const Value = Template.bind({});
+Value.args = {
+  placeholder: '카테고리를 선택해 주세요.',
+  selectedInputList: ['액세서리/패션소품', '업무 자동화', '프론트엔드', '제2의 장벽'],
+};

--- a/src/components/common/SelectInput.tsx
+++ b/src/components/common/SelectInput.tsx
@@ -20,13 +20,9 @@ const SelectInput = ({ className, placeholder, selectedInputList, href }: Select
           className={`w-full flex items-center justify-between pl-[12px] pr-[17.5px] py-[12.5px] border border-gray-200 focus:border-primary-dark focus:outline-none rounded-[8px]`}
         >
           {selectedInputList ? (
-            selectedInputList.map((selectedInput) => {
-              return (
-                <span key={uniqueId(selectedInput)} className="w-full truncate">
-                  {selectedInput}
-                </span>
-              );
-            })
+            <span key={uniqueId('selectedInput')} className="w-full text-left truncate">
+              {selectedInputList.join(', ')}
+            </span>
           ) : (
             <span className={'place-self-start text-gray-300'}>{placeholder}</span>
           )}

--- a/src/components/common/SelectInput.tsx
+++ b/src/components/common/SelectInput.tsx
@@ -12,14 +12,14 @@ interface SelectInputProps {
   href: string;
 }
 
-const SelectInput = ({ className, placeholder, selectedInputList, href }: SelectInputProps) => {
+const SelectInput = ({ className, placeholder = '', selectedInputList, href }: SelectInputProps) => {
   return (
     <div className={`w-full text-2xl ${className}`}>
       <Link href={href}>
         <button
           className={`w-full flex items-center justify-between pl-[12px] pr-[17.5px] py-[12.5px] border border-gray-200 focus:border-primary-dark focus:outline-none rounded-[8px]`}
         >
-          {selectedInputList ? (
+          {selectedInputList?.length ? (
             <span key={uniqueId('selectedInput')} className="w-full text-left truncate">
               {selectedInputList.join(', ')}
             </span>

--- a/src/components/common/SelectInput.tsx
+++ b/src/components/common/SelectInput.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+
+import { uniqueId } from '@/lib/utils';
+
+import { RightArrowIcon } from '../icons/RightArrowIcon';
+
+interface SelectInputProps {
+  className?: string;
+  placeholder?: string;
+  selectedInputList?: string[];
+  // TODO:: selectedInputList 데이터 형태에 따른 코드 수정 필요
+  href: string;
+}
+
+const SelectInput = ({ className, placeholder, selectedInputList, href }: SelectInputProps) => {
+  return (
+    <div className={`w-full text-2xl ${className}`}>
+      <Link href={href}>
+        <button
+          className={`w-full flex items-center justify-between pl-[12px] pr-[17.5px] py-[12.5px] border border-gray-200 focus:border-primary-dark focus:outline-none rounded-[8px]`}
+        >
+          {selectedInputList ? (
+            selectedInputList.map((selectedInput) => {
+              return (
+                <span key={uniqueId(selectedInput)} className="w-full truncate">
+                  {selectedInput}
+                </span>
+              );
+            })
+          ) : (
+            <span className={'place-self-start text-gray-300'}>{placeholder}</span>
+          )}
+          <RightArrowIcon />
+        </button>
+      </Link>
+    </div>
+  );
+};
+
+export default SelectInput;

--- a/src/components/common/TextInput.stories.tsx
+++ b/src/components/common/TextInput.stories.tsx
@@ -3,7 +3,7 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import TextInput from './TextInput';
 
 export default {
-  title: 'Components/TextInput',
+  title: 'Commons/TextInput',
   component: TextInput,
 } as ComponentMeta<typeof TextInput>;
 

--- a/src/components/common/TextInput.stories.tsx
+++ b/src/components/common/TextInput.stories.tsx
@@ -1,13 +1,13 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import TalentRegisterInput from './TalentRegisterInput';
+import TextInput from './TextInput';
 
 export default {
-  title: 'Components/TalentRegisterInput',
-  component: TalentRegisterInput,
-} as ComponentMeta<typeof TalentRegisterInput>;
+  title: 'Components/TextInput',
+  component: TextInput,
+} as ComponentMeta<typeof TextInput>;
 
-const Template: ComponentStory<typeof TalentRegisterInput> = (args) => <TalentRegisterInput {...args} />;
+const Template: ComponentStory<typeof TextInput> = (args) => <TextInput {...args} />;
 
 export const Title = Template.bind({});
 Title.args = {

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -14,6 +14,7 @@ export interface TextInputOptionProps {
   showCount?: boolean;
   maxLength?: number;
   error?: string;
+  className?: string;
 }
 
 interface TextInputProps {
@@ -21,12 +22,12 @@ interface TextInputProps {
 }
 
 const TextInput = ({
-  option: { key, title, explanation, placeholder, htmlFor, showCount, maxLength, error },
+  option: { key, title, explanation, placeholder, htmlFor, showCount, maxLength, error, className },
 }: TextInputProps) => {
   const [input, setInput] = useRecoilState(talentRegisterInputSelectorFamily(key));
 
   return (
-    <>
+    <div className={className}>
       {title && (
         <label htmlFor={htmlFor} className="text-t3">
           {title}
@@ -43,7 +44,7 @@ const TextInput = ({
         error={maxLength && input.contents.length >= maxLength ? error : undefined}
         className="mt-[8px]"
       />
-    </>
+    </div>
   );
 };
 

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -14,6 +14,7 @@ export interface TextInputOptionProps {
   showCount?: boolean;
   maxLength?: number;
   error?: string;
+  required?: boolean;
   className?: string;
 }
 
@@ -22,16 +23,19 @@ interface TextInputProps {
 }
 
 const TextInput = ({
-  option: { key, title, explanation, placeholder, htmlFor, showCount, maxLength, error, className },
+  option: { key, title, explanation, placeholder, htmlFor, showCount, maxLength, error, required, className },
 }: TextInputProps) => {
   const [input, setInput] = useRecoilState(talentRegisterInputSelectorFamily(key));
 
   return (
     <div className={className}>
       {title && (
-        <label htmlFor={htmlFor} className="text-t3">
-          {title}
-        </label>
+        <div>
+          <label htmlFor={htmlFor} className="text-t3">
+            {title}
+          </label>
+          {required && <span className="text-primary-red text-b4"> *</span>}
+        </div>
       )}
       {explanation && <span className="block text-b4 text-gray-400 pt-[2px]">{explanation}</span>}
       <Input

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -3,7 +3,7 @@ import { useRecoilState } from 'recoil';
 
 import { talentRegisterInputSelectorFamily } from '@/store/components/selectors';
 
-import Input from '../common/Input';
+import Input from './Input';
 
 export interface TalentRegisterInputOptionProps {
   key: string;
@@ -20,7 +20,7 @@ interface TalentRegisterInputProps {
   option: TalentRegisterInputOptionProps;
 }
 
-const TalentRegisterInput = ({
+const TextInput = ({
   option: { key, title, explanation, placeholder, htmlFor, showCount, maxLength, error },
 }: TalentRegisterInputProps) => {
   const [input, setInput] = useRecoilState(talentRegisterInputSelectorFamily(key));
@@ -47,4 +47,4 @@ const TalentRegisterInput = ({
   );
 };
 
-export default memo(TalentRegisterInput);
+export default memo(TextInput);

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -30,11 +30,11 @@ const TextInput = ({
   return (
     <div className={className}>
       {title && (
-        <div>
+        <div className="relative">
           <label htmlFor={htmlFor} className="text-t3">
             {title}
           </label>
-          {required && <span className="text-primary-red text-b4"> *</span>}
+          {required && <span className="absolute text-primary-red text-b4 ml-[3px] top-[0px]">*</span>}
         </div>
       )}
       {explanation && <span className="block text-b4 text-gray-400 pt-[2px]">{explanation}</span>}

--- a/src/components/common/TextInput.tsx
+++ b/src/components/common/TextInput.tsx
@@ -5,7 +5,7 @@ import { talentRegisterInputSelectorFamily } from '@/store/components/selectors'
 
 import Input from './Input';
 
-export interface TalentRegisterInputOptionProps {
+export interface TextInputOptionProps {
   key: string;
   title?: string;
   explanation?: string;
@@ -16,13 +16,13 @@ export interface TalentRegisterInputOptionProps {
   error?: string;
 }
 
-interface TalentRegisterInputProps {
-  option: TalentRegisterInputOptionProps;
+interface TextInputProps {
+  option: TextInputOptionProps;
 }
 
 const TextInput = ({
   option: { key, title, explanation, placeholder, htmlFor, showCount, maxLength, error },
-}: TalentRegisterInputProps) => {
+}: TextInputProps) => {
   const [input, setInput] = useRecoilState(talentRegisterInputSelectorFamily(key));
 
   return (

--- a/src/components/common/TextSelectInput.stories.tsx
+++ b/src/components/common/TextSelectInput.stories.tsx
@@ -1,0 +1,25 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import TextSelectInput from './TextSelectInput';
+
+export default {
+  title: 'Commons/TextSelectInput',
+  component: TextSelectInput,
+} as ComponentMeta<typeof TextSelectInput>;
+
+const Template: ComponentStory<typeof TextSelectInput> = (args) => <TextSelectInput {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  option: {
+    key: 'category',
+    href: 'talent/register/category',
+    title: '어떤 재능을 주고 싶나요?',
+    explanation: '',
+    placeholder: '카테고리를 선택해 주세요.',
+    htmlFor: 'category',
+    selectedInputList: ['영어'],
+    required: true,
+    className: 'mb-[28px]',
+  },
+};

--- a/src/components/common/TextSelectInput.tsx
+++ b/src/components/common/TextSelectInput.tsx
@@ -24,11 +24,11 @@ const TextSelectInput = ({
   return (
     <div className={className}>
       {title && (
-        <div>
+        <div className="relative">
           <label htmlFor={htmlFor} className="text-t3">
             {title}
           </label>
-          {required && <span className="text-primary-red text-b4"> *</span>}
+          {required && <span className="absolute text-primary-red text-b4 ml-[3px] top-[0px]">*</span>}
         </div>
       )}
       {explanation && <span className="block text-b4 text-gray-400 pt-[2px]">{explanation}</span>}

--- a/src/components/common/TextSelectInput.tsx
+++ b/src/components/common/TextSelectInput.tsx
@@ -1,0 +1,36 @@
+import React, { memo } from 'react';
+
+import SelectInput from './SelectInput';
+
+export interface TextSelectInputOptionProps {
+  key: string;
+  href: string;
+  title?: string;
+  explanation?: string;
+  placeholder?: string;
+  htmlFor?: string;
+  selectedInputList?: string[];
+  className?: string;
+}
+
+interface TextSelectInputProps {
+  option: TextSelectInputOptionProps;
+}
+
+const TextSelectInput = ({
+  option: { key, title, href, explanation, placeholder, htmlFor, selectedInputList, className },
+}: TextSelectInputProps) => {
+  return (
+    <div className={className}>
+      {title && (
+        <label htmlFor={htmlFor} className="text-t3">
+          {title}
+        </label>
+      )}
+      {explanation && <span className="block text-b4 text-gray-400 pt-[2px]">{explanation}</span>}
+      <SelectInput placeholder={placeholder} href={href} selectedInputList={selectedInputList} className="mt-[8px]" />
+    </div>
+  );
+};
+
+export default memo(TextSelectInput);

--- a/src/components/common/TextSelectInput.tsx
+++ b/src/components/common/TextSelectInput.tsx
@@ -10,6 +10,7 @@ export interface TextSelectInputOptionProps {
   placeholder?: string;
   htmlFor?: string;
   selectedInputList?: string[];
+  required?: boolean;
   className?: string;
 }
 
@@ -18,14 +19,17 @@ interface TextSelectInputProps {
 }
 
 const TextSelectInput = ({
-  option: { key, title, href, explanation, placeholder, htmlFor, selectedInputList, className },
+  option: { key, title, href, explanation, placeholder, htmlFor, selectedInputList, required, className },
 }: TextSelectInputProps) => {
   return (
     <div className={className}>
       {title && (
-        <label htmlFor={htmlFor} className="text-t3">
-          {title}
-        </label>
+        <div>
+          <label htmlFor={htmlFor} className="text-t3">
+            {title}
+          </label>
+          {required && <span className="text-primary-red text-b4"> *</span>}
+        </div>
       )}
       {explanation && <span className="block text-b4 text-gray-400 pt-[2px]">{explanation}</span>}
       <SelectInput placeholder={placeholder} href={href} selectedInputList={selectedInputList} className="mt-[8px]" />

--- a/src/components/icons/RightArrowIcon.tsx
+++ b/src/components/icons/RightArrowIcon.tsx
@@ -1,0 +1,10 @@
+import type { InternalSvgProps } from '../common/Svg';
+import Svg from '../common/Svg';
+
+export const RightArrowIcon = ({ ...props }: Partial<InternalSvgProps>) => {
+  return (
+    <Svg viewBox={[0, 0, 9, 14]} width={9} height={14} color={'none'} {...props}>
+      <path d="M1.08333 0.583332L7.5 7L1.08333 13.4167" stroke="#CFCFCF" stroke-width="1.6" stroke-linejoin="round" />;
+    </Svg>
+  );
+};

--- a/src/components/icons/RightArrowIcon.tsx
+++ b/src/components/icons/RightArrowIcon.tsx
@@ -4,7 +4,7 @@ import Svg from '../common/Svg';
 export const RightArrowIcon = ({ ...props }: Partial<InternalSvgProps>) => {
   return (
     <Svg viewBox={[0, 0, 9, 14]} width={9} height={14} color={'none'} {...props}>
-      <path d="M1.08333 0.583332L7.5 7L1.08333 13.4167" stroke="#CFCFCF" stroke-width="1.6" stroke-linejoin="round" />;
+      <path d="M1.08333 0.583332L7.5 7L1.08333 13.4167" stroke="#CFCFCF" strokeWidth="1.6" strokeLinejoin="round" />;
     </Svg>
   );
 };


### PR DESCRIPTION
## What's Changed? 
### `SelectInput` 컴포넌트를 제작했습니다 
<img width="235" alt="image" src="https://user-images.githubusercontent.com/79739512/206227512-c1b9a57d-bdf3-4dde-884d-088fd8a41d09.png">

<img width="235" alt="image" src="https://user-images.githubusercontent.com/79739512/206227548-5e4a5bce-7a50-483a-8a07-7c6b85152723.png">

```diff
+ selectedInputList?: string[];
+ href: string;
```
- `InputList`를 받아 `placeholder`에 보여줍니다. ( 데이터 형태는 추후 수정될 수 있습니다. )
- `href`를 통해 선택 이후 원하는 페이지로 이동합니다.


### `TextSelectInput` 컴포넌트를 재작했습니다.

<img width="302" alt="image" src="https://user-images.githubusercontent.com/79739512/206227329-f5d812c0-003f-438a-81c2-439b8ca10e70.png">

- `title`, `explanation`, `required`등을 설정할 수 있습니다.

### `TalentRegisterInput` 을 `TextInput`으로 변경했습니다.

- 기존 구조에서 공통으로 사용 가능한 컴포넌트로 변경하였습니다.


## Related to any issues?
- #57 

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
