### PR TITLE
fix: talent register header

### DIFF
--- a/src/components/common/HeaderTitle.tsx
+++ b/src/components/common/HeaderTitle.tsx
@@ -2,16 +2,17 @@ import { uniqueId } from '@/lib/utils';
 
 interface HeaderTitleProps {
   texts: string[];
+  textClassName?: string;
   className?: string;
 }
 
-const HeaderTitle = ({ texts, className }: HeaderTitleProps) => {
+const HeaderTitle = ({ texts, textClassName, className }: HeaderTitleProps) => {
   return (
     <h1 className={`text-h2 ${className}`}>
       {texts.map((text) => {
         const uniqueKey = uniqueId('key');
         return (
-          <span key={uniqueKey} className="block">
+          <span key={uniqueKey} className={`block ${textClassName}`}>
             {text}
           </span>
         );

--- a/src/components/talentRegister/TalentRegisterHeader.tsx
+++ b/src/components/talentRegister/TalentRegisterHeader.tsx
@@ -25,7 +25,7 @@ const TalentRegisterHeader = ({ sort, className }: TalentRegisterHeaderProps) =>
     <div className={`relative w-full h-[213px] ${color} ${className}`}>
       <IconAnchor icon={<XIcon className="absolute right-[16px] top-[60px]" />} href="/talent/register" />
       <TalentRegisterHeaderIcon className="w-full" />
-      <HeaderTitle texts={contents} className="absolute text-gray-100 left-[16px] bottom-[15.5px]" />
+      <HeaderTitle texts={contents} textClassName="text-gray-100" className="absolute left-[16px] bottom-[15.5px]" />
     </div>
   );
 };


### PR DESCRIPTION
## What's Changed? 
### TalentRegisterHeader 컴포넌트를 수정하였습니다.

<img width="258" alt="image" src="https://user-images.githubusercontent.com/79739512/206353821-4dfd7c9a-6293-40fc-b5be-f893028cdce7.png">

- color 적용이 제대로 이루어지지 않아 style을 변경하였습니다.
- 바뀐 디자인에 따라 변경이 필요합니다. 현재 디자인상 이미지파일로 되어있어 추후 논의 이후 변경이 필요합니다. 

## Related to any issues?
- #63 

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
