### PR TITLE
feat: storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,15 @@
 import '../src/styles/globals.css';
 
+import * as NextImage from 'next/image';
+
+const OriginalNextImage = NextImage.default;
+
+// eslint-disable-next-line no-import-assign
+Object.defineProperty(NextImage, 'default', {
+  configurable: true,
+  value: (props) => <OriginalNextImage {...props} unoptimized />,
+});
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {

--- a/src/components/common/Card.stories.tsx
+++ b/src/components/common/Card.stories.tsx
@@ -3,7 +3,7 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import Card from './Card';
 
 export default {
-  title: 'Main/Card',
+  title: 'Commons/Card',
   component: Card,
 } as ComponentMeta<typeof Card>;
 

--- a/src/components/common/HeaderTitle.stories.tsx
+++ b/src/components/common/HeaderTitle.stories.tsx
@@ -3,7 +3,7 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import HeaderTitle from './HeaderTitle';
 
 export default {
-  title: 'HeaderTitle',
+  title: 'Commons/HeaderTitle',
   component: HeaderTitle,
 } as ComponentMeta<typeof HeaderTitle>;
 

--- a/src/components/common/NavigationBar.stories.tsx
+++ b/src/components/common/NavigationBar.stories.tsx
@@ -3,7 +3,7 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import NavigationBar from './NavigationBar';
 
 export default {
-  title: 'NavigationBar',
+  title: 'Commons/NavigationBar',
   component: NavigationBar,
 } as ComponentMeta<typeof NavigationBar>;
 

--- a/src/components/talentRegister/TalentRegisterFormOne.stories.tsx
+++ b/src/components/talentRegister/TalentRegisterFormOne.stories.tsx
@@ -1,0 +1,143 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { RecoilRoot } from 'recoil';
+
+import useNextPage from '@/hooks/useNextPage';
+import { talentRegisterOrderAtom } from '@/store/components';
+
+import Button from '../common/Button';
+import TextInput from '../common/TextInput';
+import TextSelectInput from '../common/TextSelectInput';
+import TextTextarea from '../common/TextTextarea';
+import TalentRegisterFormOne from './TalentRegisterFormOne';
+
+const CATEGORY = {
+  SHARE: {
+    key: 'category',
+    href: 'talent/register/category/share',
+    title: '어떤 재능을 나누고 싶나요?',
+    explanation: '',
+    placeholder: '카테고리를 선택해 주세요.',
+    htmlFor: 'category',
+    selectedInputList: ['영어'],
+    required: true,
+    className: 'mb-[28px]',
+  },
+  EXCHANGE: {
+    key: 'category',
+    href: 'talent/register/category/exchange',
+    title: '어떤 재능을 주고 싶나요?',
+    explanation: '',
+    placeholder: '카테고리를 선택해 주세요.',
+    htmlFor: 'category',
+    selectedInputList: ['영어'],
+    required: true,
+    className: 'mb-[28px]',
+  },
+};
+
+const TITLE = {
+  key: 'title',
+  title: '게시글 제목',
+  explanation: '',
+  placeholder: '최대 30자 까지 입력이 가능해요.',
+  htmlFor: 'title',
+  showCount: true,
+  maxLength: 30,
+  error: '최대 30자까지 입력이 가능해요.',
+  required: true,
+  className: 'mb-[16px]',
+};
+
+const EXPLANATION = {
+  SHARE: {
+    key: 'explanation',
+    title: '상세 설명',
+    explanation: '나누고 싶은 재능에 대해 설명해 주세요.',
+    placeholder: '최대 300자 까지 입력이 가능해요.',
+    htmlFor: 'explanation',
+    maxLength: 300,
+    error: '최대 300자까지 입력이 가능해요.',
+    required: true,
+    className: 'mb-[16px]',
+  },
+  EXCHANGE: {
+    key: 'explanation',
+    title: '상세 설명',
+    explanation: '주고 싶은 재능에 대해 설명해 주세요.',
+    placeholder: '최대 300자 까지 입력이 가능해요.',
+    htmlFor: 'explanation',
+    maxLength: 300,
+    error: '최대 300자까지 입력이 가능해요.',
+    required: true,
+    className: 'mb-[16px]',
+  },
+};
+
+const LINK1 = {
+  key: 'link1',
+  title: '링크',
+  explanation: '재능을 보여줄 수 있는 링크가 있다면 입력해 주세요.(선택)',
+  placeholder: '링크를 입력해주세요.',
+  htmlFor: 'link',
+};
+
+const LINK2 = {
+  key: 'link2',
+  placeholder: '링크를 입력해주세요.',
+};
+
+const LINK3 = {
+  key: 'link3',
+  placeholder: '링크를 입력해주세요.',
+  className: 'mb-[28px]',
+};
+
+const CHAT_LINK = {
+  key: 'chatLink',
+  title: '오픈채팅 링크',
+  explanation: '카카오톡에서 오픈채팅 생성 후 링크를 붙여넣어 주세요.',
+  placeholder: '링크를 입력해주세요.',
+  htmlFor: 'openChatLink',
+  required: true,
+  className: 'mb-[24px]',
+};
+
+export default {
+  title: 'Components/TalentRegisterForm/TalentRegisterFormOne',
+  component: TalentRegisterFormOne,
+  decorators: [
+    (Story) => (
+      <RecoilRoot>
+        <Story />
+      </RecoilRoot>
+    ),
+  ],
+} as ComponentMeta<typeof TalentRegisterFormOne>;
+
+const Template: ComponentStory<typeof TalentRegisterFormOne> = (args) => {
+  const { handleOrder: onClick } = useNextPage(talentRegisterOrderAtom);
+  return (
+    <form className={`${args.className} px-[16px] py-[24.5px]`}>
+      <TextSelectInput option={CATEGORY[args.sort]} />
+      <TextInput option={TITLE} />
+      <TextTextarea option={EXPLANATION[args.sort]} />
+      <TextInput option={LINK1} />
+      <TextInput option={LINK2} />
+      <TextInput option={LINK3} />
+      <TextInput option={CHAT_LINK} />
+      <Button type="button" onClick={onClick} className="w-full">
+        다음
+      </Button>
+    </form>
+  );
+};
+
+export const Share = Template.bind({});
+Share.args = {
+  sort: 'SHARE',
+};
+
+export const Exchange = Template.bind({});
+Exchange.args = {
+  sort: 'EXCHANGE',
+};

--- a/src/components/talentRegister/TalentRegisterFormThree.stories.tsx
+++ b/src/components/talentRegister/TalentRegisterFormThree.stories.tsx
@@ -61,7 +61,7 @@ const EXPLANATION = {
 };
 
 export default {
-  title: 'Components/TalentRegisterForm/TalentRegisterFormOne',
+  title: 'Components/TalentRegisterForm/TalentRegisterFormThree',
   component: TalentRegisterFormThree,
   decorators: [
     (Story) => (

--- a/src/components/talentRegister/TalentRegisterFormThree.stories.tsx
+++ b/src/components/talentRegister/TalentRegisterFormThree.stories.tsx
@@ -1,0 +1,103 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { RecoilRoot } from 'recoil';
+
+import useBackPage from '@/hooks/useBackPage';
+import useNextPage from '@/hooks/useNextPage';
+import { talentRegisterOrderAtom } from '@/store/components';
+
+import Button from '../common/Button';
+import TextSelectInput from '../common/TextSelectInput';
+import TextTextarea from '../common/TextTextarea';
+import TalentRegisterFormThree from './TalentRegisterFormThree';
+
+const CATEGORY = {
+  SHARE: {
+    key: 'category2',
+    href: 'talent/register/category/share',
+    title: '어떤 재능을 나누고 싶나요?',
+    explanation: '',
+    placeholder: '카테고리를 선택해 주세요.',
+    htmlFor: 'category',
+    selectedInputList: ['영어'],
+    required: true,
+    className: 'mb-[28px]',
+  },
+  EXCHANGE: {
+    key: 'category2',
+    href: 'talent/register/category/exchange',
+    title: '어떤 재능을 받고 싶나요?',
+    explanation: '',
+    placeholder: '카테고리를 선택해 주세요.',
+    htmlFor: 'category',
+    selectedInputList: ['영어'],
+    required: true,
+    className: 'mb-[28px]',
+  },
+};
+
+const EXPLANATION = {
+  SHARE: {
+    key: 'explanation2',
+    title: '상세 설명',
+    explanation: '나누고 싶은 재능에 대해 설명해 주세요.',
+    placeholder: '최대 300자 까지 입력이 가능해요.',
+    htmlFor: 'explanation',
+    maxLength: 300,
+    error: '최대 300자까지 입력이 가능해요.',
+    required: true,
+    className: 'mb-[16px]',
+  },
+  EXCHANGE: {
+    key: 'explanation2',
+    title: '상세 설명',
+    explanation: '받고 싶은 재능에 대해 설명해 주세요.',
+    placeholder: '최대 300자 까지 입력이 가능해요.',
+    htmlFor: 'explanation',
+    maxLength: 300,
+    error: '최대 300자까지 입력이 가능해요.',
+    required: true,
+    className: 'mb-[16px]',
+  },
+};
+
+export default {
+  title: 'Components/TalentRegisterForm/TalentRegisterFormOne',
+  component: TalentRegisterFormThree,
+  decorators: [
+    (Story) => (
+      <RecoilRoot>
+        <Story />
+      </RecoilRoot>
+    ),
+  ],
+} as ComponentMeta<typeof TalentRegisterFormThree>;
+
+const Template: ComponentStory<typeof TalentRegisterFormThree> = (args) => {
+  const { handleOrder: onNextClick } = useNextPage(talentRegisterOrderAtom);
+  const { handleOrder: onBackClick } = useBackPage(talentRegisterOrderAtom);
+
+  return (
+    <form className={`${args.className} px-[16px] py-[24.5px]`}>
+      <TextSelectInput option={CATEGORY[args.sort]} />
+      <TextTextarea option={EXPLANATION[args.sort]} />
+      <div className="grid grid-cols-[0.3fr_1fr] gap-x-[8px]">
+        <Button buttonStyle="SECONDARY" type="button" onClick={onBackClick} className="w-full h-[48px]">
+          이전
+        </Button>
+        <Button type="button" onClick={onNextClick} className="w-full h-[48px]">
+          다음
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export const Share = Template.bind({});
+Share.args = {
+  sort: 'SHARE',
+};
+
+export const Exchange = Template.bind({});
+Exchange.args = {
+  sort: 'EXCHANGE',
+};

--- a/src/components/talentRegister/TalentRegisterFormTwo.stories.tsx
+++ b/src/components/talentRegister/TalentRegisterFormTwo.stories.tsx
@@ -1,0 +1,172 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import { RecoilRoot } from 'recoil';
+
+import useBackPage from '@/hooks/useBackPage';
+import useNextPage from '@/hooks/useNextPage';
+import { talentRegisterOrderAtom } from '@/store/components';
+
+import Button from '../common/Button';
+import TalentRegisterFormTwo from './TalentRegisterFormTwo';
+import TalentRegisterTextRadioButtonGroup from './TalentRegisterTextRadioButtonGroup';
+
+const ENVIRONMENT = {
+  SHARE: {
+    radioList: [
+      {
+        key: 'ONLINE',
+        label: '온라인',
+      },
+      {
+        key: 'OFFLINE',
+        label: '오프라인',
+      },
+      {
+        key: 'BOTH',
+        label: '상관 없음',
+      },
+    ],
+    inputKey: 'radioButtonEnvironment',
+    htmlFor: 'radioButtonEnvironment',
+    title: '재능 나눔 환경을 선택해 주세요',
+    size: 'small' as const,
+  },
+  EXCHANGE: {
+    radioList: [
+      {
+        key: 'ONLINE',
+        label: '온라인',
+      },
+      {
+        key: 'OFFLINE',
+        label: '오프라인',
+      },
+      {
+        key: 'BOTH',
+        label: '상관 없음',
+      },
+    ],
+    inputKey: 'radioButtonEnvironment',
+    htmlFor: 'radioButtonEnvironment',
+    title: '재능 교환 환경을 선택해 주세요',
+    size: 'small' as const,
+  },
+};
+
+const PERIOD = {
+  SHARE: {
+    radioList: [
+      {
+        key: 'DAYLY',
+        label: '1주 미만',
+      },
+      {
+        key: 'WEEKLY',
+        label: '1주 이상',
+      },
+      {
+        key: 'MONTHLY',
+        label: '1개월 이상',
+      },
+      {
+        key: 'NONE',
+        label: '조율 가능',
+      },
+    ],
+    inputKey: 'radioButtonPeriod',
+    htmlFor: 'radioButtonPeriod',
+    title: '재능 나눔 기간을 선택해 주세요',
+  },
+  EXCHANGE: {
+    radioList: [
+      {
+        key: 'DAYLY',
+        label: '1주 미만',
+      },
+      {
+        key: 'WEEKLY',
+        label: '1주 이상',
+      },
+      {
+        key: 'MONTHLY',
+        label: '1개월 이상',
+      },
+      {
+        key: 'NONE',
+        label: '조율 가능',
+      },
+    ],
+    inputKey: 'radioButtonPeriod',
+    htmlFor: 'radioButtonPeriod',
+    title: '재능 교환 기간을 선택해 주세요',
+  },
+};
+
+const TIME = {
+  radioList: [
+    {
+      key: 'MORNING',
+      label: '오전',
+      subLabel: '6AM - 12PM',
+    },
+    {
+      key: 'AFTERNOON',
+      label: '오후',
+      subLabel: '12PM - 6PM',
+    },
+    {
+      key: 'NIGHT',
+      label: '밤',
+      subLabel: '6PM - 12AM',
+    },
+    {
+      key: 'NONE',
+      label: '조율 가능',
+    },
+  ],
+  inputKey: 'radioButtonTime',
+  htmlFor: 'radioButtonTime',
+  title: '선호하는 시간대를 선택하세요',
+};
+
+export default {
+  title: 'Components/TalentRegisterForm/TalentRegisterFormTwo',
+  component: TalentRegisterFormTwo,
+  decorators: [
+    (Story) => (
+      <RecoilRoot>
+        <Story />
+      </RecoilRoot>
+    ),
+  ],
+} as ComponentMeta<typeof TalentRegisterFormTwo>;
+
+const Template: ComponentStory<typeof TalentRegisterFormTwo> = (args) => {
+  const { handleOrder: onNextClick } = useNextPage(talentRegisterOrderAtom);
+  const { handleOrder: onBackClick } = useBackPage(talentRegisterOrderAtom);
+
+  return (
+    <form className={`${args.className} px-[16px] py-[24.5px]`}>
+      <TalentRegisterTextRadioButtonGroup options={ENVIRONMENT[args.sort]} />
+      <TalentRegisterTextRadioButtonGroup options={PERIOD[args.sort]} />
+      <TalentRegisterTextRadioButtonGroup options={TIME} />
+      <div className="grid grid-cols-[0.3fr_1fr] gap-x-[8px]">
+        <Button buttonStyle="SECONDARY" type="button" onClick={onBackClick} className="w-full h-[48px]">
+          이전
+        </Button>
+        <Button type="button" onClick={onNextClick} className="w-full h-[48px]">
+          {args.sort === 'SHARE' ? '재능 나눔 등록하기' : '재능 교환 등록하기'}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export const Share = Template.bind({});
+Share.args = {
+  sort: 'SHARE',
+};
+
+export const Exchange = Template.bind({});
+Exchange.args = {
+  sort: 'EXCHANGE',
+};

--- a/src/components/talentRegister/TalentRegisterHeader.stories.tsx
+++ b/src/components/talentRegister/TalentRegisterHeader.stories.tsx
@@ -1,13 +1,56 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import Image from 'next/image';
+import { RecoilRoot, useRecoilValue } from 'recoil';
 
+import { talentRegisterOrderAtom } from '@/store/components';
+
+import HeaderTitle from '../common/HeaderTitle';
+import IconAnchor from '../common/IconAnchor';
+import { XIcon } from '../icons/XIcon';
 import TalentRegisterHeader from './TalentRegisterHeader';
 
 export default {
   title: 'Components/TalentRegisterHeader',
   component: TalentRegisterHeader,
+  decorators: [
+    (Story) => (
+      <RecoilRoot>
+        <Story />
+      </RecoilRoot>
+    ),
+  ],
 } as ComponentMeta<typeof TalentRegisterHeader>;
 
-const Template: ComponentStory<typeof TalentRegisterHeader> = (args) => <TalentRegisterHeader {...args} />;
+const SHARE = {
+  src: '/images/talentShare.png',
+  alt: 'talentShare',
+  contents: ['나누고 싶은 재능에 대해', '알려주세요'],
+  contents2: ['', ''],
+};
+
+const EXCHANGE = {
+  src: '/images/talentExchange.png',
+  alt: 'talentExchange',
+  contents: ['주고 싶은 재능에 대해', '알려주세요'],
+  contents2: ['받고 싶은 재능에 대해', '알려주세요'],
+};
+
+const Template: ComponentStory<typeof TalentRegisterHeader> = (args) => {
+  const { src, alt, contents, contents2 } = args.sort === 'SHARE' ? SHARE : EXCHANGE;
+  const order = useRecoilValue(talentRegisterOrderAtom);
+
+  return (
+    <div className={`relative w-full ${args.className}`}>
+      <IconAnchor icon={<XIcon className="absolute right-[16px] top-[60px]" />} href="/talent/register" />
+      <Image src={src} alt={alt} width={375} height={187} className="w-full z-99" priority />
+      <HeaderTitle
+        texts={args.sort === 'EXCHANGE' && order === 2 ? contents2 : contents}
+        textClassName="text-gray-100"
+        className="absolute left-[16px] bottom-[15.5px]"
+      />
+    </div>
+  );
+};
 
 export const Share = Template.bind({});
 Share.args = {

--- a/src/components/talentRegister/TalentRegisterHeader.tsx
+++ b/src/components/talentRegister/TalentRegisterHeader.tsx
@@ -31,7 +31,7 @@ const TalentRegisterHeader = ({ sort, className }: TalentRegisterProps) => {
       <IconAnchor icon={<XIcon className="absolute right-[16px] top-[60px]" />} href="/talent/register" />
       <Image src={src} alt={alt} width={375} height={187} className="w-full z-99" priority />
       <HeaderTitle
-        texts={sort === 'EXCHANGE' && order === 2 ? contents2 : contents}
+        texts={sort === 'EXCHANGE' && (order === 2 || order == 3) ? contents2 : contents}
         textClassName="text-gray-100"
         className="absolute left-[16px] bottom-[15.5px]"
       />

--- a/src/components/talentRegister/TalentRegisterTextRadioButtonGroup.stories.tsx
+++ b/src/components/talentRegister/TalentRegisterTextRadioButtonGroup.stories.tsx
@@ -1,0 +1,93 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import TalentRegisterTextRadioButtonGroup from './TalentRegisterTextRadioButtonGroup';
+
+export default {
+  title: 'Components/TalentRegisterTextRadioButtonGroup',
+  component: TalentRegisterTextRadioButtonGroup,
+} as ComponentMeta<typeof TalentRegisterTextRadioButtonGroup>;
+
+const Template: ComponentStory<typeof TalentRegisterTextRadioButtonGroup> = (args) => (
+  <TalentRegisterTextRadioButtonGroup {...args} />
+);
+
+export const Environment = Template.bind({});
+Environment.args = {
+  options: {
+    radioList: [
+      {
+        key: 'ONLINE',
+        label: '온라인',
+      },
+      {
+        key: 'OFFLINE',
+        label: '오프라인',
+      },
+      {
+        key: 'BOTH',
+        label: '상관 없음',
+      },
+    ],
+    inputKey: 'radioButtonEnvironment',
+    htmlFor: 'radioButtonEnvironment',
+    title: '재능 나눔 환경을 선택해 주세요',
+    size: 'small' as const,
+  },
+};
+
+export const Period = Template.bind({});
+Period.args = {
+  options: {
+    radioList: [
+      {
+        key: 'DAYLY',
+        label: '1주 미만',
+      },
+      {
+        key: 'WEEKLY',
+        label: '1주 이상',
+      },
+      {
+        key: 'MONTHLY',
+        label: '1개월 이상',
+      },
+      {
+        key: 'NONE',
+        label: '조율 가능',
+      },
+    ],
+    inputKey: 'radioButtonPeriod',
+    htmlFor: 'radioButtonPeriod',
+    title: '재능 나눔 기간을 선택해 주세요',
+  },
+};
+
+export const Time = Template.bind({});
+Time.args = {
+  options: {
+    radioList: [
+      {
+        key: 'MORNING',
+        label: '오전',
+        subLabel: '6AM - 12PM',
+      },
+      {
+        key: 'AFTERNOON',
+        label: '오후',
+        subLabel: '12PM - 6PM',
+      },
+      {
+        key: 'NIGHT',
+        label: '밤',
+        subLabel: '6PM - 12AM',
+      },
+      {
+        key: 'NONE',
+        label: '조율 가능',
+      },
+    ],
+    inputKey: 'radioButtonTime',
+    htmlFor: 'radioButtonTime',
+    title: '선호하는 시간대를 선택하세요',
+  },
+};

--- a/src/components/talentRegister/TalentRegisterTextRadioButtonGroup.tsx
+++ b/src/components/talentRegister/TalentRegisterTextRadioButtonGroup.tsx
@@ -1,10 +1,10 @@
-import type { Radio } from '@/hooks/useRadioGroup';
 import useRadioGroup from '@/hooks/useRadioGroup';
 
+import type { RadioUI } from '../common/RadioButtonGroup';
 import TextRadioButtonGroup from '../common/TextRadioButtonGroup';
 
 interface TalentRegisterTextRadioButtonGroupProp {
-  radioList: Radio[];
+  radioList: RadioUI[];
   inputKey: string;
   htmlFor: string;
   title: string;

--- a/src/pages/Home.stories.tsx
+++ b/src/pages/Home.stories.tsx
@@ -1,0 +1,13 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import Home from './index';
+
+export default {
+  title: 'Pages/Home',
+  component: Home,
+} as ComponentMeta<typeof Home>;
+
+const Template: ComponentStory<typeof Home> = () => <Home />;
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/pages/profile/Profile.stories.tsx
+++ b/src/pages/profile/Profile.stories.tsx
@@ -1,0 +1,13 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import Profile from './index';
+
+export default {
+  title: 'Pages/Profile',
+  component: Profile,
+} as ComponentMeta<typeof Profile>;
+
+const Template: ComponentStory<typeof Profile> = () => <Profile />;
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/pages/talent/register/exchange/index.tsx
+++ b/src/pages/talent/register/exchange/index.tsx
@@ -5,7 +5,7 @@ const SORT = 'EXCHANGE';
 
 const TalentRegisterExchange = () => {
   return (
-    <div className="w-[375px]">
+    <div className="w-full">
       <TalentRegisterHeader sort={SORT} />
       <TalentRegisterForm sort={SORT} />
     </div>

--- a/src/pages/talent/register/share/index.tsx
+++ b/src/pages/talent/register/share/index.tsx
@@ -5,7 +5,7 @@ const SORT = 'SHARE';
 
 const TalentRegisterShare = () => {
   return (
-    <div className="w-[375px]">
+    <div className="w-full">
       <TalentRegisterHeader sort={SORT} />
       <TalentRegisterForm sort={SORT} />
     </div>


### PR DESCRIPTION
## What's Changed? 
### `Storybook`에서 Next Image optimzed로 인한 오류를 해결했어요.
- storybook `preview.js` 에 관련 옵션을 추가했어요.

### 분류가 잘못 되어있거나 안 되어있는 컴퍼넌트의 `Story`를 분류했어요. 
- 아래와 같은 대분류로 `story`를 분류했어요.

```diff
// 현재 스토리북 폴더 분류 
+ Commons
+ Components
+ Pages
```

### 필수라고 생각되는 컴포넌트의 `Story`을 추가했어요.
- 만들어진 페이지에 대한 `story`를 모두 추가했어요.
- 재능 등록과 관련된 모든 `story`를 추가했어요.

```diff
// Page
+ Home 
+ Profile 

// Components
+ TalentRegisterForm
+ TalentRegisterTextRadioButtonGroup
+ TalentRegisterHeader
```
## Screenshots

![image](https://user-images.githubusercontent.com/79739512/207284956-839c3940-d4d8-42d8-ace5-4777dc01e8c9.png)



## Related to any issues?
- #83 

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
