### PR TITLE
feat: talent register category 2

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -37,10 +37,21 @@ export const queryFetcher = async (url: string, queries?: Record<string, unknown
 export const mutateFetcher = async <T>(
   url: string,
   method: 'POST' | 'PUT' | 'DELETE',
+  data?: T,
   params?: Record<string, unknown>,
 ): Promise<T | null> => {
   try {
-    const res = await axios({ url, method, params });
+    // FIXME: axios config 관련 리팩토링 필요
+    const res = await axios({
+      url,
+      method,
+      data,
+      params,
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_TOKEN} `,
+        'Content-Type': 'application/json',
+      },
+    });
 
     return res.data;
   } catch (err) {

--- a/src/components/common/ClickTag.tsx
+++ b/src/components/common/ClickTag.tsx
@@ -1,0 +1,40 @@
+import useTab from '@/hooks/useTab';
+
+import { XIcon } from '../icons/XIcon';
+
+interface ClickTagProps {
+  categoryKey: string;
+  id: number;
+  name: string;
+  sort: 'SHARE' | 'EXCHANGE';
+  isDelete?: boolean;
+  className?: string;
+}
+
+const ClickTag = ({ categoryKey, id, name, sort, isDelete = false, className }: ClickTagProps) => {
+  const { onClick, clicked } = useTab({
+    key: categoryKey,
+    id,
+    selectingNumber: categoryKey === 'subCategoryId' ? 1 : 5,
+  });
+
+  const color =
+    sort === 'SHARE'
+      ? 'border-primary-red bg-primary-red text-white'
+      : 'border-primary-blue bg-primary-blue text-white';
+  const style = clicked ? color : 'border-gray-300 bg-white text-gray-500 ';
+
+  return (
+    <button
+      type="button"
+      id={`${id}`}
+      className={`flex items-center ${style} border py-4 rounded-full text-b2 px-[14px] w-fit whitespace-nowrap ${className}`}
+      onClick={onClick}
+    >
+      {name}
+      {isDelete && <XIcon size={10} className="ml-[8px]" />}
+    </button>
+  );
+};
+
+export default ClickTag;

--- a/src/components/common/ClickTagList.tsx
+++ b/src/components/common/ClickTagList.tsx
@@ -1,0 +1,36 @@
+import type { TagProps } from '@/store/components/types';
+
+import ClickTag from './ClickTag';
+
+interface ClickTagListProps {
+  categoryKey: string;
+  list: TagProps[];
+  sort: 'SHARE' | 'EXCHANGE';
+  isDelete?: boolean;
+  className?: string;
+}
+
+const ClickTagList = ({ categoryKey, list, sort, isDelete = false, className = '' }: ClickTagListProps) => {
+  return (
+    <ul className={`${className} flex flex-wrap`}>
+      {list.map(({ id, name }) => {
+        return (
+          <li key={id} className="pr-[8px]">
+            {
+              <ClickTag
+                categoryKey={categoryKey}
+                id={id}
+                name={name}
+                sort={sort}
+                isDelete={isDelete}
+                className={'mb-[8px]'}
+              />
+            }
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default ClickTagList;

--- a/src/components/common/SelectInput.tsx
+++ b/src/components/common/SelectInput.tsx
@@ -1,14 +1,14 @@
 import Link from 'next/link';
 
 import { uniqueId } from '@/lib/utils';
+import type { TagProps } from '@/store/components/types';
 
 import { RightArrowIcon } from '../icons/RightArrowIcon';
 
 interface SelectInputProps {
   className?: string;
   placeholder?: string;
-  selectedInputList?: string[];
-  // TODO:: selectedInputList 데이터 형태에 따른 코드 수정 필요
+  selectedInputList?: TagProps[];
   href: string;
 }
 
@@ -20,11 +20,11 @@ const SelectInput = ({ className, placeholder = '', selectedInputList, href }: S
           className={`w-full flex items-center justify-between pl-[12px] pr-[17.5px] py-[12.5px] border border-gray-200 focus:border-primary-dark focus:outline-none rounded-[8px]`}
         >
           {selectedInputList?.length === 0 ? (
-            <span key={uniqueId('selectedInput')} className="w-full text-left truncate">
-              {selectedInputList.join(', ')}
-            </span>
-          ) : (
             <span className={'place-self-start text-gray-300'}>{placeholder}</span>
+          ) : (
+            <span key={uniqueId('selectedInput')} className="w-full text-left truncate">
+              {selectedInputList?.map((list) => list.name).join(', ')}
+            </span>
           )}
           <RightArrowIcon />
         </button>

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -22,7 +22,7 @@ const Tag = ({ styleType = TagStyleType.DARK, color = 'blue', children, classNam
           ? 'border border-primary-blue bg-white text-primary-blue'
           : 'border border-primary-red bg-white text-primary-red';
       case 'NONE':
-        return 'border border-gray-300 bg-white text-gray-500 text-b2 px-[14px] py-[6.5px]';
+        return 'border border-gray-300 bg-white text-gray-500 text-b2 px-[14px]';
     }
   };
 

--- a/src/components/common/TextSelectInput.tsx
+++ b/src/components/common/TextSelectInput.tsx
@@ -1,4 +1,7 @@
 import React, { memo } from 'react';
+import { useRecoilValue } from 'recoil';
+
+import { tabAtomFamily } from '@/store/components';
 
 import SelectInput from './SelectInput';
 
@@ -9,7 +12,6 @@ export interface TextSelectInputOptionProps {
   explanation?: string;
   placeholder?: string;
   htmlFor?: string;
-  selectedInputList?: string[];
   required?: boolean;
   className?: string;
 }
@@ -19,8 +21,10 @@ interface TextSelectInputProps {
 }
 
 const TextSelectInput = ({
-  option: { title, href, explanation, placeholder, htmlFor, selectedInputList, required, className },
+  option: { key, title, href, explanation, placeholder, htmlFor, required, className },
 }: TextSelectInputProps) => {
+  const input = useRecoilValue(tabAtomFamily(key));
+
   return (
     <div className={className}>
       {title && (
@@ -32,7 +36,7 @@ const TextSelectInput = ({
         </div>
       )}
       {explanation && <span className="block text-b4 text-gray-400 pt-[2px]">{explanation}</span>}
-      <SelectInput placeholder={placeholder} href={href} selectedInputList={selectedInputList} className="mt-[8px]" />
+      <SelectInput placeholder={placeholder} href={href} selectedInputList={input} className="mt-[8px]" />
     </div>
   );
 };

--- a/src/components/talentRegister/TalentRegisterCategoryBottomSheet.tsx
+++ b/src/components/talentRegister/TalentRegisterCategoryBottomSheet.tsx
@@ -1,0 +1,42 @@
+import type { PropsWithChildren } from 'react';
+import { useRecoilValue } from 'recoil';
+
+import { tabAtomFamily } from '@/store/components';
+
+import ClickTagList from '../common/ClickTagList';
+
+interface TalentRegisterCategoryBottomSheetProps {
+  sort: 'SHARE' | 'EXCHANGE';
+  categoryKey: string;
+  className?: string;
+}
+
+const TalentRegisterCategoryBottomSheet = ({
+  sort,
+  categoryKey,
+  children,
+  className,
+}: PropsWithChildren<TalentRegisterCategoryBottomSheetProps>) => {
+  const selectedTab = useRecoilValue(tabAtomFamily(categoryKey));
+
+  return (
+    <>
+      {selectedTab.length === 0 ? (
+        <div className="fixed left-0 bottom-0 w-full px-[16px] py-[20px]">{children}</div>
+      ) : (
+        <div className={`w-full bg-[#FAFAFA] fixed left-0 bottom-0 z-10 px-[16px] py-[20px] ${className}`}>
+          <span className="text-t4 text-gray-600">선택한 재능 카테고리</span>
+          <ClickTagList
+            categoryKey={categoryKey}
+            list={selectedTab}
+            sort={sort}
+            isDelete={true}
+            className={'pt-[8px] pb-[20px]'}
+          />
+          {children}
+        </div>
+      )}
+    </>
+  );
+};
+export default TalentRegisterCategoryBottomSheet;

--- a/src/components/talentRegister/TalentRegisterCategoryTabList.tsx
+++ b/src/components/talentRegister/TalentRegisterCategoryTabList.tsx
@@ -1,7 +1,6 @@
 import useGetCategory from '@/hooks/useGetCategory';
 
 import TabList from '../common/TabList';
-import Tag from '../common/Tag';
 
 const TalentRegisterCategoryTabList = () => {
   const { isLoading, data } = useGetCategory({ sort: 'main' });

--- a/src/components/talentRegister/TalentRegisterCategoryTagList.tsx
+++ b/src/components/talentRegister/TalentRegisterCategoryTagList.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { useRecoilValue } from 'recoil';
+
+import type { TalentRegisterProps } from '@/constants/talentRegister/talentRegisterType';
+import useGetCategory from '@/hooks/useGetCategory';
+import { SetTalnetRegisterCategorySelectInputKey } from '@/lib/utils';
+import { tabAtomFamily } from '@/store/components';
+
+import Button from '../common/Button';
+import ClickTagList from '../common/ClickTagList';
+import TalentRegisterCategoryBottomSheet from './TalentRegisterCategoryBottomSheet';
+
+interface MidAndSubCategoriesProps extends CategoryProps {
+  subCategories: CategoryProps[];
+}
+
+const TalentRegisterCategoryTagList = ({ sort, className }: TalentRegisterProps) => {
+  const [{ id }] = useRecoilValue(tabAtomFamily('mainCategory'));
+  const categoryKey = SetTalnetRegisterCategorySelectInputKey();
+  const selectedTab = useRecoilValue(tabAtomFamily(categoryKey));
+  const { isSuccess, data } = useGetCategory({
+    sort: 'mid',
+    query: 'mainCategoryId',
+    categoryId: id || 1,
+  });
+
+  const href = sort === 'SHARE' ? '/talent/register/share' : '/talent/register/exchange';
+
+  const onClick = () => {
+    return;
+  };
+
+  return (
+    <form className={`${className} px-[16px] py-[24.5px]`}>
+      {isSuccess &&
+        data.data.map(({ id, name, subCategories }: MidAndSubCategoriesProps) => {
+          return (
+            <div key={id}>
+              <span className="text-t4 text-gray-600">{name}</span>
+              <ClickTagList
+                key={id}
+                categoryKey={categoryKey}
+                list={subCategories}
+                sort={sort}
+                className={'pt-[8px] pb-[20px]'}
+              />
+            </div>
+          );
+        })}
+      <TalentRegisterCategoryBottomSheet sort={sort} categoryKey={categoryKey}>
+        <Link href={href} className="block">
+          <Button type="button" onClick={onClick} disabled={selectedTab.length === 0} className="w-full">
+            선택 완료
+          </Button>
+        </Link>
+      </TalentRegisterCategoryBottomSheet>
+    </form>
+  );
+};
+
+export default TalentRegisterCategoryTagList;

--- a/src/components/talentRegister/TalentRegisterFormOne.tsx
+++ b/src/components/talentRegister/TalentRegisterFormOne.tsx
@@ -1,6 +1,10 @@
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+
 import type { TalentRegisterProps } from '@/constants/talentRegister/talentRegisterType';
 import useNextPage from '@/hooks/useNextPage';
-import { talentRegisterOrderAtom } from '@/store/components';
+import { SetTalnetRegisterCategorySelectInputKey } from '@/lib/utils';
+import { talentRegisterMethodAtom, talentRegisterOrderAtom } from '@/store/components';
 
 import Button from '../common/Button';
 import TextInput from '../common/TextInput';
@@ -9,24 +13,22 @@ import TextTextarea from '../common/TextTextarea';
 
 const CATEGORY = {
   SHARE: {
-    key: 'category',
+    key: 'subCategory',
     href: '/talent/register/share/category',
     title: '어떤 재능을 나누고 싶나요?',
     explanation: '',
     placeholder: '카테고리를 선택해 주세요.',
     htmlFor: 'category',
-    selectedInputList: [''],
     required: true,
     className: 'mb-[28px]',
   },
   EXCHANGE: {
-    key: 'category',
+    key: 'subCategory',
     href: '/talent/register/exchange/category',
     title: '어떤 재능을 주고 싶나요?',
     explanation: '',
     placeholder: '카테고리를 선택해 주세요.',
     htmlFor: 'category',
-    selectedInputList: [''],
     required: true,
     className: 'mb-[28px]',
   },
@@ -47,7 +49,7 @@ const TITLE = {
 
 const EXPLANATION = {
   SHARE: {
-    key: 'explanation',
+    key: 'content',
     title: '상세 설명',
     explanation: '나누고 싶은 재능에 대해 설명해 주세요.',
     placeholder: '최대 300자 까지 입력이 가능해요.',
@@ -58,7 +60,7 @@ const EXPLANATION = {
     className: 'mb-[16px]',
   },
   EXCHANGE: {
-    key: 'explanation',
+    key: 'content',
     title: '상세 설명',
     explanation: '주고 싶은 재능에 대해 설명해 주세요.',
     placeholder: '최대 300자 까지 입력이 가능해요.',
@@ -101,10 +103,20 @@ const CHAT_LINK = {
 
 const TalentRegisterFormOne = ({ className, sort }: TalentRegisterProps) => {
   const { handleOrder: onClick } = useNextPage(talentRegisterOrderAtom);
+  const setMethod = useSetRecoilState(talentRegisterMethodAtom);
+  const categoryKey = SetTalnetRegisterCategorySelectInputKey();
+
+  useEffect(() => {
+    if (sort === 'SHARE') {
+      setMethod(false);
+    } else {
+      setMethod(true);
+    }
+  }, [setMethod, sort]);
 
   return (
     <form className={`${className} px-[16px] py-[24.5px]`}>
-      <TextSelectInput option={CATEGORY[sort]} />
+      <TextSelectInput option={{ ...CATEGORY[sort], key: categoryKey }} />
       <TextInput option={TITLE} />
       <TextTextarea option={EXPLANATION[sort]} />
       <TextInput option={LINK1} />

--- a/src/components/talentRegister/TalentRegisterFormThree.tsx
+++ b/src/components/talentRegister/TalentRegisterFormThree.tsx
@@ -1,6 +1,7 @@
 import type { TalentRegisterProps } from '@/constants/talentRegister/talentRegisterType';
 import useBackPage from '@/hooks/useBackPage';
 import useNextPage from '@/hooks/useNextPage';
+import { SetTalnetRegisterCategorySelectInputKey } from '@/lib/utils';
 import { talentRegisterOrderAtom } from '@/store/components';
 
 import Button from '../common/Button';
@@ -34,7 +35,7 @@ const CATEGORY = {
 
 const EXPLANATION = {
   SHARE: {
-    key: 'explanation2',
+    key: 'takenContent',
     title: '상세 설명',
     explanation: '나누고 싶은 재능에 대해 설명해 주세요.',
     placeholder: '최대 300자 까지 입력이 가능해요.',
@@ -45,7 +46,7 @@ const EXPLANATION = {
     className: 'mb-[16px]',
   },
   EXCHANGE: {
-    key: 'explanation2',
+    key: 'takenContent',
     title: '상세 설명',
     explanation: '받고 싶은 재능에 대해 설명해 주세요.',
     placeholder: '최대 300자 까지 입력이 가능해요.',
@@ -60,10 +61,11 @@ const EXPLANATION = {
 const TalentRegisterFormThree = ({ className, sort }: TalentRegisterProps) => {
   const { handleOrder: onNextClick } = useNextPage(talentRegisterOrderAtom);
   const { handleOrder: onBackClick } = useBackPage(talentRegisterOrderAtom);
+  const categoryKey = SetTalnetRegisterCategorySelectInputKey();
 
   return (
     <form className={`${className} px-[16px] py-[24.5px]`}>
-      <TextSelectInput option={CATEGORY[sort]} />
+      <TextSelectInput option={{ ...CATEGORY[sort], key: categoryKey }} />
       <TextTextarea option={EXPLANATION[sort]} />
       <div className="grid grid-cols-[0.3fr_1fr] gap-x-[8px]">
         <Button buttonStyle="SECONDARY" type="button" onClick={onBackClick} className="w-full h-[48px]">

--- a/src/components/talentRegister/TalentRegisterFormTwo.tsx
+++ b/src/components/talentRegister/TalentRegisterFormTwo.tsx
@@ -1,7 +1,10 @@
+import { useRecoilValue } from 'recoil';
+
 import type { TalentRegisterProps } from '@/constants/talentRegister/talentRegisterType';
 import useBackPage from '@/hooks/useBackPage';
-import useNextPage from '@/hooks/useNextPage';
+import useRegisterTalentPost from '@/hooks/useRegisterTalentPost';
 import { talentRegisterOrderAtom } from '@/store/components';
+import { talentRegisterSelector } from '@/store/components/selectors';
 
 import Button from '../common/Button';
 import TalentRegisterTextRadioButtonGroup from './TalentRegisterTextRadioButtonGroup';
@@ -18,11 +21,11 @@ const ENVIRONMENT = {
         label: '오프라인',
       },
       {
-        key: 'BOTH',
+        key: 'ANY_TYPE',
         label: '상관 없음',
       },
     ],
-    inputKey: 'radioButtonEnvironment',
+    inputKey: 'exchangeType',
     htmlFor: 'radioButtonEnvironment',
     title: '재능 나눔 환경을 선택해 주세요',
     size: 'small' as const,
@@ -38,11 +41,11 @@ const ENVIRONMENT = {
         label: '오프라인',
       },
       {
-        key: 'BOTH',
+        key: 'ANY_TYPE',
         label: '상관 없음',
       },
     ],
-    inputKey: 'radioButtonEnvironment',
+    inputKey: 'exchangeType',
     htmlFor: 'radioButtonEnvironment',
     title: '재능 교환 환경을 선택해 주세요',
     size: 'small' as const,
@@ -53,46 +56,46 @@ const PERIOD = {
   SHARE: {
     radioList: [
       {
-        key: 'DAYLY',
+        key: 'A_WEEK',
         label: '1주 미만',
       },
       {
-        key: 'WEEKLY',
+        key: 'LESS_THAN_A_MONTH',
         label: '1주 이상',
       },
       {
-        key: 'MONTHLY',
+        key: 'MORE_THAN_A_MONTH',
         label: '1개월 이상',
       },
       {
-        key: 'NONE',
+        key: 'ANY_PERIOD',
         label: '조율 가능',
       },
     ],
-    inputKey: 'radioButtonPeriod',
+    inputKey: 'exchangePeriod',
     htmlFor: 'radioButtonPeriod',
     title: '재능 나눔 기간을 선택해 주세요',
   },
   EXCHANGE: {
     radioList: [
       {
-        key: 'DAYLY',
+        key: 'A_WEEK',
         label: '1주 미만',
       },
       {
-        key: 'WEEKLY',
+        key: 'LESS_THAN_A_MONTH',
         label: '1주 이상',
       },
       {
-        key: 'MONTHLY',
+        key: 'MORE_THAN_A_MONTH',
         label: '1개월 이상',
       },
       {
-        key: 'NONE',
+        key: 'ANY_PERIOD',
         label: '조율 가능',
       },
     ],
-    inputKey: 'radioButtonPeriod',
+    inputKey: 'exchangePeriod',
     htmlFor: 'radioButtonPeriod',
     title: '재능 교환 기간을 선택해 주세요',
   },
@@ -101,7 +104,7 @@ const PERIOD = {
 const TIME = {
   radioList: [
     {
-      key: 'MORNING',
+      key: 'NOON',
       label: '오전',
       subLabel: '6AM - 12PM',
     },
@@ -111,23 +114,24 @@ const TIME = {
       subLabel: '12PM - 6PM',
     },
     {
-      key: 'NIGHT',
+      key: 'EVENING',
       label: '밤',
       subLabel: '6PM - 12AM',
     },
     {
-      key: 'NONE',
+      key: 'ANY_TIME',
       label: '조율 가능',
     },
   ],
-  inputKey: 'radioButtonTime',
+  inputKey: 'exchangeTime',
   htmlFor: 'radioButtonTime',
   title: '선호하는 시간대를 선택하세요',
 };
 
 const TalentRegisterFormTwo = ({ className, sort }: TalentRegisterProps) => {
-  const { handleOrder: onNextClick } = useNextPage(talentRegisterOrderAtom);
   const { handleOrder: onBackClick } = useBackPage(talentRegisterOrderAtom);
+  const talentInfo = useRecoilValue(talentRegisterSelector);
+  const { mutate } = useRegisterTalentPost();
 
   return (
     <form className={`${className} px-[16px] py-[24.5px]`}>
@@ -138,7 +142,7 @@ const TalentRegisterFormTwo = ({ className, sort }: TalentRegisterProps) => {
         <Button buttonStyle="SECONDARY" type="button" onClick={onBackClick} className="w-full h-[48px]">
           이전
         </Button>
-        <Button type="button" onClick={onNextClick} className="w-full h-[48px]">
+        <Button type="button" onClick={() => mutate(talentInfo)} className="w-full h-[48px]">
           {sort === 'SHARE' ? '재능 나눔 등록하기' : '재능 교환 등록하기'}
         </Button>
       </div>

--- a/src/hooks/useRegisterTalentPost.ts
+++ b/src/hooks/useRegisterTalentPost.ts
@@ -1,0 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { mutateFetcher } from '@/apis';
+
+const useRegisterTalentPost = () => {
+  const mutation = useMutation({
+    mutationFn: (talentInfo: string) => mutateFetcher('/posts', 'POST', talentInfo),
+  });
+  return mutation;
+};
+
+export default useRegisterTalentPost;

--- a/src/hooks/useRegisterTalentPost.ts
+++ b/src/hooks/useRegisterTalentPost.ts
@@ -1,10 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { mutateFetcher } from '@/apis';
+import type { TalentRegisterInfoProps } from '@/store/components/types';
 
 const useRegisterTalentPost = () => {
   const mutation = useMutation({
-    mutationFn: (talentInfo: string) => mutateFetcher('/posts', 'POST', talentInfo),
+    mutationFn: (talentInfo: TalentRegisterInfoProps) => mutateFetcher('/posts', 'POST', JSON.stringify(talentInfo)),
   });
   return mutation;
 };

--- a/src/hooks/useTab.ts
+++ b/src/hooks/useTab.ts
@@ -11,6 +11,12 @@ interface UseTabProps {
   selectingNumber?: number;
 }
 
+/** TODO: 추후 수정 필요
+ * 로직을 recoil 안에다 작성하려다가 밖으로 빼서 작성하였는데 key 관리 관련해서 문제가 있습니다.
+ * 추후에 해당 로직을 recoil 안에다 작성하는 것이 유지보수 측면에서 유리할 듯 합니다.
+ */
+
+// TODO: useTab example 추가하기
 const useTab = ({ key, id, selectingNumber = 1 }: UseTabProps) => {
   const [selectedTab, setSelectedTab] = useRecoilState<TabProps[]>(tabAtomFamily(key));
   const [clicked, setClicked] = useState(false);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,7 @@
+import type { TalentRegisterInputInfo } from '@/store/components/types';
+
+export interface MakeAndRemoveAtomKeyProps {
+  prev: string[];
+  newInput: TalentRegisterInputInfo;
+  input: TalentRegisterInputInfo;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,9 @@
+import { useRecoilValue } from 'recoil';
+
+import { talentRegisterOrderAtom } from '@/store/components';
+
+import type { MakeAndRemoveAtomKeyProps } from './types';
+
 export const formatQueryString = (url: string, queryObject?: Record<string, unknown>): string => {
   if (!queryObject) {
     return url;
@@ -16,4 +22,16 @@ export const formatQueryString = (url: string, queryObject?: Record<string, unkn
 
 export const uniqueId = (id?: string | number) => {
   return id + Math.random().toString(16).slice(2);
+};
+
+export const SetTalnetRegisterCategorySelectInputKey = () => {
+  const order = useRecoilValue(talentRegisterOrderAtom);
+
+  return order === 1 ? 'subCategoryId' : 'takenTalentIds';
+};
+
+export const makeAndRemoveAtomKey = ({ prev, newInput, input }: MakeAndRemoveAtomKeyProps) => {
+  return newInput.contents.length === 0
+    ? prev.filter((prevInput) => prevInput !== input.inputKey)
+    : Array.from(new Set([...prev, input.inputKey]));
 };

--- a/src/pages/talent/register/exchange/category/index.tsx
+++ b/src/pages/talent/register/exchange/category/index.tsx
@@ -1,5 +1,6 @@
 import TalentRegisterCategotyHeader from '@/components/talentRegister/TalentRegisterCategoryHeader';
 import TalentRegisterCategoryTabList from '@/components/talentRegister/TalentRegisterCategoryTabList';
+import TalentRegisterCategoryTagList from '@/components/talentRegister/TalentRegisterCategoryTagList';
 
 // 중복되는 코드로 추후 리팩토링 필요
 const sort = 'EXCHANGE';
@@ -7,8 +8,9 @@ const sort = 'EXCHANGE';
 const TalentRegisterExchangeCategory = () => {
   return (
     <>
-      <TalentRegisterCategotyHeader sort={sort} />;
+      <TalentRegisterCategotyHeader sort={sort} />
       <TalentRegisterCategoryTabList />
+      <TalentRegisterCategoryTagList sort={sort} />
     </>
   );
 };

--- a/src/pages/talent/register/share/category/index.tsx
+++ b/src/pages/talent/register/share/category/index.tsx
@@ -1,5 +1,6 @@
 import TalentRegisterCategotyHeader from '@/components/talentRegister/TalentRegisterCategoryHeader';
 import TalentRegisterCategoryTabList from '@/components/talentRegister/TalentRegisterCategoryTabList';
+import TalentRegisterCategoryTagList from '@/components/talentRegister/TalentRegisterCategoryTagList';
 
 // 중복되는 코드로 추후 리팩토링 필요
 const sort = 'SHARE';
@@ -9,6 +10,7 @@ const TalentRegisterShareCategory = () => {
     <>
       <TalentRegisterCategotyHeader sort={sort} />
       <TalentRegisterCategoryTabList />
+      <TalentRegisterCategoryTagList sort={sort} />
     </>
   );
 };

--- a/src/store/components/atoms.ts
+++ b/src/store/components/atoms.ts
@@ -2,9 +2,23 @@ import { atom, atomFamily } from 'recoil';
 
 import type { TabProps, TalentRegisterInputInfo } from './types';
 
+// TODO: tabAtom의 경우 key를 찾기 쉽지 않아 key 관리를 위한 좋은 방법이 필요합니다.
 const tabAtomFamily = atomFamily<TabProps[], string>({
   key: 'tab',
-  default: () => [{ id: 1, name: '' }],
+  default: (inputKey) => {
+    switch (inputKey) {
+      case 'mainCategory':
+        return [{ id: 1, name: '' }];
+      default:
+        return [];
+    }
+  },
+});
+
+// TODO: 수동으로 받고 있는 tabKeyAtom을 동적으로 변경하는 코드가 필요합니다.
+const tabKeyAtom = atom<string[]>({
+  key: 'talentRegisterInputKey',
+  default: ['subCategoryId', 'takenTalentIds'],
 });
 
 const toastAtom = atom<string | null>({
@@ -29,19 +43,7 @@ const headerAtom = atom<Header | null>({
 
 const talentRegisterAtom = atom({
   key: 'talentRegister',
-  default: {
-    title: '',
-    content: '',
-    isShare: false,
-    subCategoryId: 0,
-    links: ['', '', ''],
-    chatLink: '',
-    takenTalentIds: [0, 0, 0],
-    takenContent: '',
-    exchangeType: '',
-    exchangePeriod: '',
-    exchangeTime: '',
-  },
+  default: {},
 });
 
 const talentRegisterOrderAtom = atom({
@@ -55,6 +57,11 @@ const talentRegisterInputKeyAtom = atom<string[]>({
   default: [],
 });
 
+const talentRegisterInputLinkKeyAtom = atom<string[]>({
+  key: 'talentRegisterInputListKey',
+  default: [],
+});
+
 /* INFO::
  * atomFamily를 통해 input atom을 동적으로 생성하고 관리할 수 있습니다.
  * atom은 고유한 inputKey를 통해 구분되어집니다.
@@ -64,14 +71,22 @@ const talentRegisterInputAtomFamily = atomFamily<TalentRegisterInputInfo, string
   default: (inputKey) => ({ inputKey, contents: '' }),
 });
 
+const talentRegisterMethodAtom = atom({
+  key: 'talentRegisterMethod',
+  default: false,
+});
+
 export {
   bottomSheetAtom,
   headerAtom,
   popupAtom,
   tabAtomFamily,
+  tabKeyAtom,
   talentRegisterAtom,
   talentRegisterInputAtomFamily,
   talentRegisterInputKeyAtom,
+  talentRegisterInputLinkKeyAtom,
+  talentRegisterMethodAtom,
   talentRegisterOrderAtom,
   toastAtom,
 };

--- a/src/store/components/selectors.ts
+++ b/src/store/components/selectors.ts
@@ -1,10 +1,17 @@
-import { selector, selectorFamily } from 'recoil';
+import { DefaultValue, selector, selectorFamily } from 'recoil';
 
-import { talentRegisterInputAtomFamily, talentRegisterInputKeyAtom } from './atoms';
-import type { TalentRegisterInputInfo } from './types';
+import { makeAndRemoveAtomKey } from '@/lib/utils';
+
+import {
+  tabAtomFamily,
+  talentRegisterInputAtomFamily,
+  talentRegisterInputKeyAtom,
+  talentRegisterInputLinkKeyAtom,
+  talentRegisterMethodAtom,
+} from './atoms';
+import type { TalentRegisterInfoProps, TalentRegisterInputInfo } from './types';
 
 // INFO:: selectorFamily를 통해 Key 관리 작업을 recoil 내에서 처리할 수 있습니다.
-// TODO:: input 데이터가 ''일시 keyAtom에서 제거하는 작업이 필요합니다.
 const talentRegisterInputSelectorFamily = selectorFamily<TalentRegisterInputInfo, string>({
   key: 'talentRegisterInputSelector',
   get:
@@ -16,7 +23,13 @@ const talentRegisterInputSelectorFamily = selectorFamily<TalentRegisterInputInfo
     ({ get, set }, newInput) => {
       const input = get(talentRegisterInputAtomFamily(inputKey));
 
-      set(talentRegisterInputKeyAtom, (prev) => Array.from(new Set([...prev, input.inputKey])));
+      if (!(newInput instanceof DefaultValue)) {
+        if (input.inputKey.includes('link')) {
+          set(talentRegisterInputLinkKeyAtom, (prev) => makeAndRemoveAtomKey({ prev, newInput, input }));
+        } else {
+          set(talentRegisterInputKeyAtom, (prev) => makeAndRemoveAtomKey({ prev, newInput, input }));
+        }
+      }
       set(talentRegisterInputAtomFamily(inputKey), newInput);
     },
 });
@@ -24,12 +37,8 @@ const talentRegisterInputSelectorFamily = selectorFamily<TalentRegisterInputInfo
 const talentRegisterLinksSelector = selector({
   key: 'talentRegisterLinksSelector',
   get: ({ get }) => {
-    const keyList = get(talentRegisterInputKeyAtom);
-
-    const linkKeyList = keyList.filter((key) => {
-      return key.includes('link');
-    });
-    const linkList = linkKeyList.map((key) => {
+    const keyList = get(talentRegisterInputLinkKeyAtom);
+    const linkList = keyList.map((key) => {
       const link = get(talentRegisterInputAtomFamily(key));
       return link.contents;
     });
@@ -38,4 +47,42 @@ const talentRegisterLinksSelector = selector({
   },
 });
 
-export { talentRegisterInputSelectorFamily, talentRegisterLinksSelector };
+const talentRegisterTakenCategoriesSelector = selector({
+  key: 'talentRegisterTakenCategories',
+  get: ({ get }) => {
+    const takenTalentCategories = get(tabAtomFamily('takenTalentIds'));
+    const takentTalentIds = takenTalentCategories.map((category) => category.id);
+
+    return takentTalentIds;
+  },
+});
+
+const talentRegisterSelector = selector({
+  key: 'talentRegisterSelector',
+  get: ({ get }) => {
+    const talentRegisterInfo: TalentRegisterInfoProps = {};
+
+    const isShare = get(talentRegisterMethodAtom);
+    talentRegisterInfo['isShare'] = isShare;
+
+    // TODO: 추후 동적 Key 관리가 필요합니다.
+    const subCategory = get(tabAtomFamily('subCategoryId'));
+    if (subCategory?.length > 0) talentRegisterInfo['subCategoryId'] = subCategory[0].id;
+
+    const inputKeys = get(talentRegisterInputKeyAtom);
+    inputKeys.forEach((inputKey) => {
+      const input = get(talentRegisterInputAtomFamily(inputKey));
+      talentRegisterInfo[input.inputKey] = input.contents;
+    });
+
+    const links = get(talentRegisterLinksSelector);
+    if (links.length > 0) talentRegisterInfo['links'] = links;
+
+    const takenTalentIds = get(talentRegisterTakenCategoriesSelector);
+    if (takenTalentIds?.length > 0) talentRegisterInfo['takenTalentIds'] = takenTalentIds;
+
+    return talentRegisterInfo;
+  },
+});
+
+export { talentRegisterInputSelectorFamily, talentRegisterLinksSelector, talentRegisterSelector };

--- a/src/store/components/types.ts
+++ b/src/store/components/types.ts
@@ -3,9 +3,17 @@ interface TabProps {
   name: string;
 }
 
+interface TagProps {
+  id: number;
+  name: string;
+}
+
 interface TalentRegisterInputInfo {
   inputKey: string;
   contents: string;
 }
+interface TalentRegisterInfoProps {
+  [index: string]: string | string[] | number[] | boolean | number;
+}
 
-export type { TabProps, TalentRegisterInputInfo };
+export type { TabProps, TagProps, TalentRegisterInfoProps, TalentRegisterInputInfo };

--- a/src/typings/common.d.ts
+++ b/src/typings/common.d.ts
@@ -66,3 +66,7 @@ interface PostInfo {
   ranks: string;
   isLike: false;
 }
+interface CategoryProps {
+  id: number;
+  name: string;
+}


### PR DESCRIPTION
## What's Changed? 
### `ClickTag` 컴포넌트를 추가했어요.
- 기존 `Tag` 컴포넌트에서 `click` 로직을 분리하기 위해 새로운 컴포넌트를 만들었어요.
- `delete` 아이콘이 추가되었어요.

### `ClickTagList` 컴포넌트를 추가했어요.

| ClickTag | ClickTag (delete) |
|---|---|
| <img width="244" alt="image" src="https://user-images.githubusercontent.com/79739512/208225397-262ab62c-4440-4f62-9bad-4164b5356df8.png"> | <img width="205" alt="image" src="https://user-images.githubusercontent.com/79739512/208225425-5163cfe8-edc0-48e0-91e3-b39f4ba1a491.png"> |

### `TalentRegisterCategoryBottomSheet` 컴포넌트를 추가했어요.
- 재능 등록 카테고리 선택시 아래 나오는 바텀 시트를 추가했어요.

<img width="293" alt="image" src="https://user-images.githubusercontent.com/79739512/208225550-4c02fa25-a659-443a-aecd-e7c3388a81b1.png">

### `TalentRegisterCategoryTagList` 컴포넌트를 추가했어요.

<img width="296" alt="image" src="https://user-images.githubusercontent.com/79739512/208225635-6f1da094-0c83-41bf-ade1-e850926af333.png">

### 재능 등록에 필요한 `atom`과 `selector`를 추가했어요.
- 동적으로 만들어진 `atom`에 접근하기 위한 `key atom`들을 추가했어요.
- 재능 등록에 필요한 `body object`를 만드는 `selector`를 추가했어요.

### ⚠️ 발생한 문제
- `useTab`에서 상태 관리 로직을 `hook` 내부에 작성하면서 `key` 관리가 어려워졌어요.
- 추후에 `useTab` 로직을 `recoil` 로직으로 옮기는 과정이 필요해요. 

```javascript
// TODO: 수동으로 받고 있는 tabKeyAtom을 동적으로 변경하는 코드가 필요합니다.
const tabKeyAtom = atom<string[]>({
  key: 'talentRegisterInputKey',
  default: ['subCategoryId', 'takenTalentIds'],
});
```

## Related to any issues?
- #85 

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
