### PR TITLE
:bug: fix: Add /api/v1 to next config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -32,7 +32,7 @@ const nextConfig = {
     return [
       {
         source: '/:path*',
-        destination: `https://${process.env.NEXT_PUBLIC_SERVER_URL}/:path*`,
+        destination: `${process.env.NEXT_PUBLIC_SERVER_URL}/api/v1/:path*`,
       },
     ];
   },

--- a/next.config.js
+++ b/next.config.js
@@ -32,7 +32,7 @@ const nextConfig = {
     return [
       {
         source: '/:path*',
-        destination: `${process.env.NEXT_PUBLIC_SERVER_URL}/api/v1/:path*`,
+        destination: `https://${process.env.NEXT_PUBLIC_SERVER_URL}/api/v1/:path*`,
       },
     ];
   },

--- a/src/hooks/queries/useCategoriesQuery.ts
+++ b/src/hooks/queries/useCategoriesQuery.ts
@@ -11,7 +11,7 @@ const useCategoriesQuery = () => {
   const fetchCategories = async () => {
     const {
       data: { data },
-    } = await axiosClient.get<ServerResponse<MainCategory[]>>(`/api/v1/categories/main`);
+    } = await axiosClient.get<ServerResponse<MainCategory[]>>(`/categories/main`);
     return data;
   };
 

--- a/src/hooks/queries/useCustomPostsQuery.ts
+++ b/src/hooks/queries/useCustomPostsQuery.ts
@@ -18,7 +18,7 @@ const useCustomPostsQuery = (params: CustomPostsQueryParams) => {
   const fetchCustomPosts = async ({ subCategoryId, page, size }: CustomPostsQueryParams) => {
     const {
       data: { data },
-    } = await axiosClient.get<ServerResponse<CustomPostsData>>(`/api/v1/posts/custom`, {
+    } = await axiosClient.get<ServerResponse<CustomPostsData>>(`/posts/custom`, {
       params: {
         subCategoryId,
         page,

--- a/src/hooks/queries/useInfinitePostsQuery.ts
+++ b/src/hooks/queries/useInfinitePostsQuery.ts
@@ -22,7 +22,7 @@ const useInfinitePostsQuery = () => {
   const fetchPosts = async ({ pageParam = DEFAULT_PAGE }: QueryFunctionContext): Promise<InfinitePost> => {
     const {
       data: { data },
-    } = await axiosClient.get('/api/v1/posts', {
+    } = await axiosClient.get('/posts', {
       params: {
         isShare: false,
         page: pageParam,

--- a/src/hooks/queries/usePostLikeMutate.ts
+++ b/src/hooks/queries/usePostLikeMutate.ts
@@ -11,7 +11,7 @@ const usePostLikeMutate = (postId: number) => {
   const updatePostLikeByPostId = async (postId: number): Promise<LikeInfo> => {
     const {
       data: { data },
-    } = await axiosClient.post(`api/v1/posts/${postId}/likes`, {});
+    } = await axiosClient.post(`/posts/${postId}/likes`, {});
 
     return data;
   };

--- a/src/hooks/queries/usePostQuery.ts
+++ b/src/hooks/queries/usePostQuery.ts
@@ -8,7 +8,7 @@ const usePostQuery = (id: number) => {
   const fetchPostById = async (id: number) => {
     const {
       data: { data },
-    } = await axiosClient.get<ServerResponse<PostInfo>>(`/api/v1/posts/${id}`);
+    } = await axiosClient.get<ServerResponse<PostInfo>>(`/posts/${id}`);
     return data;
   };
 

--- a/src/hooks/queries/usePostUnlikeMutate.ts
+++ b/src/hooks/queries/usePostUnlikeMutate.ts
@@ -10,7 +10,7 @@ const usePostUnlikeMutate = (postId: number) => {
   const updatePostUnlikeByPostId = async (postId: number): Promise<LikeInfo> => {
     const {
       data: { data },
-    } = await axiosClient.post(`api/v1/posts/${postId}/unlikes`, {});
+    } = await axiosClient.post(`/posts/${postId}/unlikes`, {});
 
     return data;
   };

--- a/src/hooks/queries/useUserInfoQuery.ts
+++ b/src/hooks/queries/useUserInfoQuery.ts
@@ -8,7 +8,7 @@ const useUserInfoQuery = () => {
   const fetchUserInfo = async () => {
     const {
       data: { data },
-    } = await axiosClient.get<ServerResponse<UserInfo>>(`/api/v1/members/1`);
+    } = await axiosClient.get<ServerResponse<UserInfo>>(`/members/1`);
     return data;
   };
 

--- a/src/hooks/useGetCategory.ts
+++ b/src/hooks/useGetCategory.ts
@@ -14,7 +14,7 @@ const useGetCategory = ({ sort, query, categoryId }: UseCategoryProps) => {
   // TODO: useQuery type 선언이 필요합니다.
   const results = useQuery({
     queryKey: [`${sort}`, `${query}`, `${categoryId}`],
-    queryFn: () => queryFetcher(`categories/${sort}`, queries),
+    queryFn: () => queryFetcher(`/categories/${sort}`, queries),
   });
 
   return results;


### PR DESCRIPTION
## What's Changed? 
- next.config.js 의 rewrites에 `/api/vi` 추가하고 호출부의 url에서는 모두 삭제
- NEXT_PUBLIC_SERVER_URL 은 next.config에 rewrites 에서 https:// prefix 붙이기를 권장하여 변경하지 않았습니다.
<img width="1111" alt="Screen Shot 2022-12-27 at 7 28 49 PM" src="https://user-images.githubusercontent.com/46391618/209653320-1722a6c9-98b1-48db-97c1-c455732de2a7.png">

.env.development
```
NEXT_PUBLIC_SERVER_URL="dev-be.ping-pong.world"
```

.env.production
```
NEXT_PUBLIC_SERVER_URL="be.ping-pong.world"
```


## Screenshots

<img width="1920" alt="Screen Shot 2022-12-27 at 7 19 57 PM" src="https://user-images.githubusercontent.com/46391618/209652611-83f4d366-433d-4f41-b7ca-69d66071e733.png">
<img width="1920" alt="Screen Shot 2022-12-27 at 7 19 51 PM" src="https://user-images.githubusercontent.com/46391618/209652616-5a16be59-94f0-4a29-ae37-f957f04e3e27.png">

## Related to any issues?
- ⛔️

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
