### PR TITLE
Fix: 게시글 상세 페이지 안나오는 이슈

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -35,7 +35,7 @@ const nextConfig = {
   rewrites: async () => {
     return [
       {
-        source: '/:path*',
+        source: '/.api/:path*',
         destination: `https://${process.env.NEXT_PUBLIC_SERVER_URL}/api/v1/:path*`,
       },
     ];

--- a/src/hooks/queries/useCategoriesQuery.ts
+++ b/src/hooks/queries/useCategoriesQuery.ts
@@ -12,14 +12,14 @@ const useCategoriesQuery = (midCategoryId?: number) => {
   const fetchMainMidCategories = async () => {
     const {
       data: { data },
-    } = await axiosClient.get<ServerResponse<MainCategory[]>>(`/categories/main`);
+    } = await axiosClient.get<ServerResponse<MainCategory[]>>(`/.api/categories/main`);
     return data;
   };
 
   const fetchSubCategoriesByMidCategoryId = async () => {
     const {
       data: { data },
-    } = await axiosClient.get<ServerResponse<SubCategory[]>>(`/categories/sub`, {
+    } = await axiosClient.get<ServerResponse<SubCategory[]>>(`/.api/categories/sub`, {
       params: {
         midCategoryId,
       },

--- a/src/hooks/queries/useCustomPostsQuery.ts
+++ b/src/hooks/queries/useCustomPostsQuery.ts
@@ -22,7 +22,7 @@ const useCustomPostsQuery = (params: CustomPostsQueryParams) => {
   const fetchCustomPosts = async ({ subCategoryId, page, size }: CustomPostsQueryParams) => {
     const {
       data: { data },
-    } = await axiosClient.get<ServerResponse<CustomPostsData>>(`/posts/custom`, {
+    } = await axiosClient.get<ServerResponse<CustomPostsData>>(`/.api/posts/custom`, {
       params: {
         subCategoryId,
         page,

--- a/src/hooks/queries/useInfinitePostsQuery.ts
+++ b/src/hooks/queries/useInfinitePostsQuery.ts
@@ -37,7 +37,7 @@ const useInfinitePostsQuery = (params: CategoryFilterParams) => {
   }: PostParams): Promise<InfinitePost> => {
     const {
       data: { data },
-    } = await axiosClient.get('/posts', {
+    } = await axiosClient.get('/.api/posts', {
       params: {
         isShare,
         mainCategory,

--- a/src/hooks/queries/usePostLikeMutate.ts
+++ b/src/hooks/queries/usePostLikeMutate.ts
@@ -11,7 +11,7 @@ const usePostLikeMutate = (postId: number) => {
   const updatePostLikeByPostId = async (postId: number): Promise<LikeInfo> => {
     const {
       data: { data },
-    } = await axiosClient.post(`/posts/${postId}/likes`, {});
+    } = await axiosClient.post(`/.api/posts/${postId}/likes`, {});
 
     return data;
   };

--- a/src/hooks/queries/usePostQuery.ts
+++ b/src/hooks/queries/usePostQuery.ts
@@ -8,7 +8,7 @@ const usePostQuery = (id: number) => {
   const fetchPostById = async (id: number) => {
     const {
       data: { data },
-    } = await axiosClient.get<ServerResponse<PostInfo>>(`/posts/${id}`);
+    } = await axiosClient.get<ServerResponse<PostInfo>>(`/.api/posts/${id}`);
     return data;
   };
 

--- a/src/hooks/queries/usePostUnlikeMutate.ts
+++ b/src/hooks/queries/usePostUnlikeMutate.ts
@@ -10,7 +10,7 @@ const usePostUnlikeMutate = (postId: number) => {
   const updatePostUnlikeByPostId = async (postId: number): Promise<LikeInfo> => {
     const {
       data: { data },
-    } = await axiosClient.post(`/posts/${postId}/unlikes`, {});
+    } = await axiosClient.post(`/.api/posts/${postId}/unlikes`, {});
 
     return data;
   };

--- a/src/hooks/queries/useUserInfoQuery.ts
+++ b/src/hooks/queries/useUserInfoQuery.ts
@@ -12,7 +12,7 @@ const useUserInfoQuery = () => {
   const fetchUserInfo = async () => {
     const {
       data: { data },
-    } = await axiosClient.get<ServerResponse<UserInfo>>(`/members/1`);
+    } = await axiosClient.get<ServerResponse<UserInfo>>(`/.api/members/1`);
     return data;
   };
 

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -4,8 +4,6 @@ import { useEffect } from 'react';
 import styled from 'styled-components';
 
 import BottomFixedBar from '@/components/common/BottomFixedBar';
-import BottomSheet from '@/components/common/BottomSheet';
-import BottomSheetOptions from '@/components/common/BottomSheetOptions';
 import Button from '@/components/common/Button';
 import CircleImg from '@/components/common/CircleImg';
 import LikeButton from '@/components/common/LikeButton';
@@ -22,9 +20,7 @@ import type { LinkInfo } from '@/typings/common';
 
 const PostDetail = () => {
   const router = useRouter();
-
   const postId = Number(router.query.id) || 0;
-
   const mockImage =
     'https://images.unsplash.com/photo-1671210681777-4b7d2377ef69?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80';
 
@@ -38,8 +34,10 @@ const PostDetail = () => {
   };
 
   useEffect(() => {
+    if (!postIsSuccess) return;
+
     refetch();
-  }, [postLikeIsSuccess, postUnlikeIsSuccess, refetch]);
+  }, [postLikeIsSuccess, postUnlikeIsSuccess, postIsSuccess, refetch]);
 
   useEffect(() => {
     addBottomSheetOptions([


### PR DESCRIPTION
## What's Changed? 
### 원인
localhost 뒤의 path 전체가 rewrites 되어 
localhost/posts/8 이 dynamic route인 `posts/[id].tsx` 라우터로 접근되지 않고 실제 `/posts/8` API 로 접근되어 json이 표시됨. 

### 해결
api 호출하는 부분에 `/.api` 붙여서 해결
-> 이후 api 연결 시 `/.api` prefix를 붙여서 사용해야합니다. 
@L2HYUNN @hwangyena 

## Screenshots

<img width="518" alt="Screen Shot 2022-12-30 at 1 18 20 AM" src="https://user-images.githubusercontent.com/46391618/209980927-6915ee18-c956-4701-8400-b38420b61363.png">

## Related to any issues?
- 게시글 상세 페이지 접근 시 api response json 나오는 이슈

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
