### PR TITLE
feat: 프로필 페이지에서 내가쓴글 포스트 확인용 isMyPost query 추가

### DIFF
--- a/src/components/posts/PostHeader.tsx
+++ b/src/components/posts/PostHeader.tsx
@@ -7,13 +7,13 @@ import PostHeaderNav from './PostHeaderNav';
 
 interface PostHeaderProps {
   imageUrl: string;
-  isMine?: boolean;
+  isMyPost?: boolean;
 }
 
-const PostHeader = ({ imageUrl, isMine }: PostHeaderProps) => {
+const PostHeader = ({ imageUrl, isMyPost }: PostHeaderProps) => {
   return (
     <HeaderContainer>
-      <PostHeaderNav isMine={isMine} />
+      <PostHeaderNav isMyPost={isMyPost} />
       <ImageWrapper className="relative" width="100%" height="18.7rem">
         <Image
           alt="post-header"

--- a/src/components/posts/PostHeaderNav.tsx
+++ b/src/components/posts/PostHeaderNav.tsx
@@ -6,12 +6,12 @@ import useBottomSheet from '@/hooks/useBottomSheet';
 import ArrowLeftIcon from '../../../public/icons/arrow-left.svg';
 import MoreIcon from '../../../public/icons/more.svg';
 
-const PostHeaderNav = ({ isMine = false }: { isMine?: boolean }) => {
+const PostHeaderNav = ({ isMyPost = false }: { isMyPost?: boolean }) => {
   const router = useRouter();
   const { openBottomSheet, addBottomSheetOptions } = useBottomSheet();
 
   const onClickMore = () => {
-    isMine
+    isMyPost
       ? addBottomSheetOptions([{ id: 'DELETE', label: '게시글 삭제' }])
       : addBottomSheetOptions([{ id: 'REPORT', label: '사용자 신고하기' }]);
     openBottomSheet();

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -25,8 +25,6 @@ import type { LinkInfo, PopupProps } from '@/typings/common';
 const PostDetail = () => {
   const router = useRouter();
   const postId = Number(router.query.id) || 0;
-  const mockImage =
-    'https://images.unsplash.com/photo-1671210681777-4b7d2377ef69?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80';
 
   const [popup, setPopup] = useRecoilState<PopupProps | null>(popupAtom);
   const [reportReason, setReportReason] = useState<string>('');
@@ -64,8 +62,8 @@ const PostDetail = () => {
   }, [postLikeIsSuccess, postUnlikeIsSuccess, postIsSuccess, refetch]);
 
   useEffect(() => {
-    const isMine = router.asPath.includes('isMine');
-    setIsMyPost(isMine);
+    const pathHasIsMyPost = router.asPath.includes('isMyPost');
+    setIsMyPost(pathHasIsMyPost);
   }, [router]);
 
   useEffect(() => {
@@ -79,7 +77,7 @@ const PostDetail = () => {
     <>
       {postIsSuccess && (
         <>
-          <PostHeader isMine={isMyPost} imageUrl={postData.backgroundImage} />
+          <PostHeader isMyPost={isMyPost} imageUrl={postData.backgroundImage} />
           <Layout.DetailContainer>
             <Layout.DefaultPadding>
               <ProfileContainer className="mb-16 pb-16">
@@ -89,9 +87,11 @@ const PostDetail = () => {
                   <aside>{postData.ranks}</aside>
                 </ProfileInfo>
                 <Link href={`/profile/${postData.memberId}`}>
-                  <ProfileLinkButton>
-                    <Typography.Desc>프로필보기</Typography.Desc>
-                  </ProfileLinkButton>
+                  {!isMyPost && (
+                    <ProfileLinkButton>
+                      <Typography.Desc>프로필보기</Typography.Desc>
+                    </ProfileLinkButton>
+                  )}
                 </Link>
               </ProfileContainer>
               {postData.isShare ? (

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -86,13 +86,13 @@ const PostDetail = () => {
                   <h5>{postData.nickname}</h5>
                   <aside>{postData.ranks}</aside>
                 </ProfileInfo>
-                <Link href={`/profile/${postData.memberId}`}>
-                  {!isMyPost && (
+                {!isMyPost && (
+                  <Link href={`/profile/${postData.memberId}`}>
                     <ProfileLinkButton>
                       <Typography.Desc>프로필보기</Typography.Desc>
                     </ProfileLinkButton>
-                  )}
-                </Link>
+                  </Link>
+                )}
               </ProfileContainer>
               {postData.isShare ? (
                 <>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -116,7 +116,9 @@ export default function Profile() {
             {posts.map((item) => {
               return (
                 <li key={item.id}>
-                  <Card hideProfile {...item} />
+                  <Link href={`/posts/${item.id}?isMyPost=true`}>
+                    <Card hideProfile {...item} />
+                  </Link>
                 </li>
               );
             })}


### PR DESCRIPTION
## What's Changed? 
### 프로필 페이지에서 카드 클릭해서 이동시 isMyPost query 추가 
-> 게시글 상세 이동 후 query로 파악해서 아래UI가 분기처리가 됩니다. 

### `...` 더보기 버튼 클릭 시 
내가쓴글: '게시물 삭제' 표시
다른사람글: '신고하기' 표시

### 프로필 보기 버튼
내가쓴글: 프로필 보기 버튼 미노출
다른사람글: 프로필 보기 노출

## Screenshots
<img width="1212" alt="Screen Shot 2022-12-31 at 11 04 04 PM" src="https://user-images.githubusercontent.com/46391618/210139353-4e9f9bc3-266d-48f9-94f6-7009cc082411.png">
<img width="1226" alt="Screen Shot 2022-12-31 at 11 03 58 PM" src="https://user-images.githubusercontent.com/46391618/210139359-e30fb495-a429-44eb-a55a-954a9e73cd71.png">


## Related to any issues?
- ⛔️

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
