### PR TITLE
Feat: 탈퇴하기 API 연결

### DIFF
--- a/src/components/common/Popup.tsx
+++ b/src/components/common/Popup.tsx
@@ -15,6 +15,7 @@ const Popup = ({ children, content, title, cancelText, confirmText, onCancel, on
   };
 
   const onConfirmClicked = () => {
+    console.log('onConfirmClicked');
     onConfirm && onConfirm();
 
     setPopup(null);

--- a/src/components/common/Popup.tsx
+++ b/src/components/common/Popup.tsx
@@ -15,7 +15,6 @@ const Popup = ({ children, content, title, cancelText, confirmText, onCancel, on
   };
 
   const onConfirmClicked = () => {
-    console.log('onConfirmClicked');
     onConfirm && onConfirm();
 
     setPopup(null);
@@ -25,8 +24,10 @@ const Popup = ({ children, content, title, cancelText, confirmText, onCancel, on
     <Portal isShowing className="fixed w-screen h-screen left-0 top-0 grid place-items-center px-[6%] z-[100]">
       <div className="rounded-[16px] w-full bg-white z-50">
         <main className="px-5 py-[8%] flex items-center gap-2 flex-col">
-          <h1 className="text-t2 text-center text-gray-600">{title}</h1>
-          {content && <p className="text-gray-400 text-center text-b2" dangerouslySetInnerHTML={{ __html: content }} />}
+          <h1 className="text-t1 text-center text-gray-600">{title}</h1>
+          {content && (
+            <p className="text-gray-400 text-center text-b3 mt-4" dangerouslySetInnerHTML={{ __html: content }} />
+          )}
           {children}
         </main>
         <footer className="flex w-full text-[15px] items-center justify-center border-t-[1px] border-gray-150">

--- a/src/components/posts/PostReportRadioGroup.tsx
+++ b/src/components/posts/PostReportRadioGroup.tsx
@@ -13,7 +13,10 @@ const PostReportRadioGroup = ({ setReportReason }: { setReportReason: (value: st
     { key: 'POST_REPORT_4', label: '욕설이나 비방이 포함되어 있어요.' },
     { key: 'POST_REPORT_5', label: '외설적인 내용이 포함되어 있어요.' },
   ];
-  const { list, currentSelected, onChange } = useRadioGroup({ list: reportReasonList });
+  const { list, currentSelected, onChange } = useRadioGroup({
+    list: reportReasonList,
+    initialValue: reportReasonList[0],
+  });
 
   useEffect(() => {
     if (!currentSelected) return;

--- a/src/components/setting/DeleteAccountRadioGroup.tsx
+++ b/src/components/setting/DeleteAccountRadioGroup.tsx
@@ -13,11 +13,14 @@ const DeleteAccountRadioGroup = ({ setDeleteReason }: { setDeleteReason: (value:
     { key: 'DELETE_ACCOUNT_4', label: '불쾌감을 주는 사용자를 만났어요.' },
     { key: 'DELETE_ACCOUNT_5', label: '새로운 계정으로 가입하고 싶어요.' },
   ];
-  const { list, currentSelected, onChange } = useRadioGroup({ list: deleteReasonList });
+  const { list, currentSelected, onChange } = useRadioGroup({
+    list: deleteReasonList,
+    initialValue: deleteReasonList[0],
+  });
 
   useEffect(() => {
     if (!currentSelected) return;
-    console.log('setDeleteReason');
+
     setDeleteReason(currentSelected.label);
   }, [currentSelected, setDeleteReason]);
 

--- a/src/components/setting/DeleteAccountRadioGroup.tsx
+++ b/src/components/setting/DeleteAccountRadioGroup.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import styled from 'styled-components';
+
+import useRadioGroup from '@/hooks/useRadioGroup';
+
+import RadioGroup from '../common/RadioGroup';
+
+const DeleteAccountRadioGroup = ({ setDeleteReason }: { setDeleteReason: (value: string) => void }) => {
+  const deleteReasonList = [
+    { key: 'DELETE_ACCOUNT_1', label: '원하는 재능이 없어요.' },
+    { key: 'DELETE_ACCOUNT_2', label: '재능을 등록하는 과정이 불편해요.' },
+    { key: 'DELETE_ACCOUNT_3', label: '재능을 교환/나눔하는 과정이 불편해요.' },
+    { key: 'DELETE_ACCOUNT_4', label: '불쾌감을 주는 사용자를 만났어요.' },
+    { key: 'DELETE_ACCOUNT_5', label: '새로운 계정으로 가입하고 싶어요.' },
+  ];
+  const { list, currentSelected, onChange } = useRadioGroup({ list: deleteReasonList });
+
+  useEffect(() => {
+    if (!currentSelected) return;
+    console.log('setDeleteReason');
+    setDeleteReason(currentSelected.label);
+  }, [currentSelected, setDeleteReason]);
+
+  return (
+    <DeleteAccountRadioGroupContainer>
+      <RadioGroup currentSelected={currentSelected} list={list} onChange={onChange} />
+    </DeleteAccountRadioGroupContainer>
+  );
+};
+
+export default DeleteAccountRadioGroup;
+
+const DeleteAccountRadioGroupContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 2.4rem;
+`;

--- a/src/hooks/queries/useDeleteAccountMutate.ts
+++ b/src/hooks/queries/useDeleteAccountMutate.ts
@@ -4,7 +4,6 @@ import { axiosClient } from '@/apis';
 
 const useDeleteAccountMutate = () => {
   const deleteAccount = async ({ content }: { content: string }) => {
-    console.log('deleteAccount');
     const {
       data: { data },
     } = await axiosClient.delete(`/members/me`, {

--- a/src/hooks/queries/useDeleteAccountMutate.ts
+++ b/src/hooks/queries/useDeleteAccountMutate.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { axiosClient } from '@/apis';
+
+const useDeleteAccountMutate = () => {
+  const deleteAccount = async ({ content }: { content: string }) => {
+    console.log('deleteAccount');
+    const {
+      data: { data },
+    } = await axiosClient.delete(`/members/me`, {
+      data: {
+        content,
+      },
+    });
+
+    return data;
+  };
+
+  return useMutation({
+    mutationFn: ({ content }: { content: string }) => deleteAccount({ content }),
+    onSuccess: () => {
+      // TODO: open toast with message
+    },
+  });
+};
+
+export default useDeleteAccountMutate;

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -45,6 +45,7 @@ const PostDetail = () => {
   const handleReportPopup = useCallback(() => {
     setPopup({
       title: '사용자 신고하기',
+      content: '신고 사유를 선택해주세요.',
       children: <PostReportRadioGroup setReportReason={setReportReason} />,
       onConfirm: () =>
         reportPostMutate({

--- a/src/pages/setting/index.tsx
+++ b/src/pages/setting/index.tsx
@@ -24,6 +24,7 @@ export default function ProfileSetting() {
   const hanldeDeletePopup = useCallback(() => {
     setPopup({
       title: 'Ping-Pong 서비스 탈퇴하기',
+      content: `불편하셨던 점을 저희에게 말씀해주세요.<br/>서비스 개선에 적극 반영하도록 할게요.`,
       children: <DeleteAccountRadioGroup setDeleteReason={setDeleteReason} />,
       onConfirm: () => deleteAccountMutate({ content: deleteReason }),
       confirmText: '선택 완료',

--- a/src/pages/setting/index.tsx
+++ b/src/pages/setting/index.tsx
@@ -1,6 +1,9 @@
 import Image from 'next/image';
 import { useRouter } from 'next/router';
+import { useCallback, useEffect, useState } from 'react';
 
+import DeleteAccountRadioGroup from '@/components/setting/DeleteAccountRadioGroup';
+import useDeleteAccountMutate from '@/hooks/queries/useDeleteAccountMutate';
 import { useAuth } from '@/hooks/useAuth';
 import useHeader from '@/hooks/useHeader';
 import { usePopupWithBlock } from '@/hooks/usePopupWithBlock';
@@ -14,6 +17,19 @@ export default function ProfileSetting() {
   const handleMoveToLink = (path: string) => {
     router.push(path);
   };
+
+  const [deleteReason, setDeleteReason] = useState('');
+  const { mutate: deleteAccountMutate } = useDeleteAccountMutate();
+
+  const hanldeDeletePopup = useCallback(() => {
+    setPopup({
+      title: 'Ping-Pong 서비스 탈퇴하기',
+      children: <DeleteAccountRadioGroup setDeleteReason={setDeleteReason} />,
+      onConfirm: () => deleteAccountMutate({ content: deleteReason }),
+      confirmText: '선택 완료',
+      cancelText: '취소',
+    });
+  }, [setDeleteReason, setPopup, deleteAccountMutate, deleteReason]);
 
   const settingList = [
     { label: '알림 설정', onClick: () => handleMoveToLink('/setting/alarm') },
@@ -33,8 +49,15 @@ export default function ProfileSetting() {
         });
       },
     },
-    { label: '탈퇴하기', onClick: () => null },
+    {
+      label: '탈퇴하기',
+      onClick: hanldeDeletePopup,
+    },
   ];
+
+  useEffect(() => {
+    hanldeDeletePopup();
+  }, [deleteReason, hanldeDeletePopup]);
 
   useHeader({
     title: '설정',


### PR DESCRIPTION
## What's Changed? 

탈퇴하기 API 연결
- DeleteAccountRadioGroup
- useDeleteAccountMutate 추가

신고하기, 탈퇴하기 API 팝업
- default 값 선택되어있도록 initialValue 추가
- title, content 스타일 디자인에 맞추어 수정

## Screenshots
<img width="1004" alt="Screen Shot 2023-01-01 at 3 56 58 PM" src="https://user-images.githubusercontent.com/46391618/210163249-b05b7118-3c72-4c56-a5b2-02adbfe6b7c8.png">
<img width="985" alt="Screen Shot 2023-01-01 at 3 56 33 PM" src="https://user-images.githubusercontent.com/46391618/210163251-a3e95176-bf6b-4928-bf43-61dd962f9f1a.png">

## Related to any issues?
- ⛔️

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
