### PR TITLE
Fix: 신고하기 탈퇴하기 토스트 메세지, 오픈채팅 이동 컨펌창 노출

### DIFF
--- a/src/hooks/queries/useDeleteAccountMutate.ts
+++ b/src/hooks/queries/useDeleteAccountMutate.ts
@@ -2,7 +2,11 @@ import { useMutation } from '@tanstack/react-query';
 
 import { axiosClient } from '@/apis';
 
+import { useToast } from '../useToast';
+
 const useDeleteAccountMutate = () => {
+  const { setToast } = useToast();
+
   const deleteAccount = async ({ content }: { content: string }) => {
     const {
       data: { data },
@@ -17,9 +21,8 @@ const useDeleteAccountMutate = () => {
 
   return useMutation({
     mutationFn: ({ content }: { content: string }) => deleteAccount({ content }),
-    onSuccess: () => {
-      // TODO: open toast with message
-    },
+    onSuccess: () => setToast('탈퇴 처리가 완료되었어요. 😢'),
+    onError: () => setToast('탈퇴 처리에 실패했어요.'),
   });
 };
 

--- a/src/hooks/queries/useReportPostMutate.ts
+++ b/src/hooks/queries/useReportPostMutate.ts
@@ -19,7 +19,7 @@ const useReportPostMutate = () => {
 
   return useMutation({
     mutationFn: ({ postId, content }: { postId: number; content: string }) => createReportByPostId({ postId, content }),
-    onSuccess: () => setToast('신고 처리가 완료되었어요. 😢'),
+    onSuccess: () => setToast('신고 처리가 완료되었어요.'),
     onError: () => setToast('신고 처리에 실패했어요.'),
   });
 };

--- a/src/hooks/queries/useReportPostMutate.ts
+++ b/src/hooks/queries/useReportPostMutate.ts
@@ -2,7 +2,11 @@ import { useMutation } from '@tanstack/react-query';
 
 import { axiosClient } from '@/apis';
 
+import { useToast } from '../useToast';
+
 const useReportPostMutate = () => {
+  const { setToast } = useToast();
+
   const createReportByPostId = async ({ postId, content }: { postId: number; content: string }) => {
     const {
       data: { data },
@@ -15,6 +19,8 @@ const useReportPostMutate = () => {
 
   return useMutation({
     mutationFn: ({ postId, content }: { postId: number; content: string }) => createReportByPostId({ postId, content }),
+    onSuccess: () => setToast('신고 처리가 완료되었어요. 😢'),
+    onError: () => setToast('신고 처리에 실패했어요.'),
   });
 };
 

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -27,7 +27,6 @@ const PostDetail = () => {
   const router = useRouter();
   const postId = Number(router.query.id) || 0;
 
-  const [popup, setPopup] = useRecoilState<PopupProps | null>(popupAtom);
   const [reportReason, setReportReason] = useState<string>('');
   const [isMyPost, setIsMyPost] = useState(false);
   const activeOption = useRecoilValue(bottomSheetActiveOptionAtom);
@@ -37,6 +36,7 @@ const PostDetail = () => {
   const { mutate: postUnlikeMutate, isSuccess: postUnlikeIsSuccess } = usePostUnlikeMutate(postId);
   const { mutate: postDeleteMutate, isSuccess: postDeleteIsSuccess } = usePostDeleteMutate(postId);
   const { mutate: reportPostMutate, isSuccess: reportPostIsSuccess } = useReportPostMutate();
+  const { setPopup } = usePopupWithBlock();
 
   const handleLike = () => {
     postData?.isLike ? postUnlikeMutate() : postLikeMutate();

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -57,6 +57,25 @@ const PostDetail = () => {
     });
   }, [setPopup, reportPostMutate, postId, reportReason]);
 
+  const handleKakaoLinkPopup = useCallback(
+    (link: string) => {
+      const openExternalLink = (link: string) => {
+        if (!window) return;
+
+        window.open(`//${link}`, '_blank');
+      };
+
+      setPopup({
+        title: '카카오톡 오픈채팅으로 이동됩니다',
+        content: '오픈채팅 시, 상대방에게 <br />불쾌감을 주는 언어 사용을 지양해주세요.',
+        onConfirm: () => openExternalLink(link),
+        confirmText: '이동하기',
+        cancelText: '취소',
+      });
+    },
+    [setPopup],
+  );
+
   useEffect(() => {
     if (!postIsSuccess) return;
 
@@ -151,10 +170,8 @@ const PostDetail = () => {
               count={postData.likes.toString()}
               onClick={handleLike}
             />
-            <Button className="ml-12">
-              <a href={postData.chatLink} target="_blank" rel="noreferrer">
-                오픈채팅 시작하기
-              </a>
+            <Button className="ml-12" onClick={() => handleKakaoLinkPopup(postData.chatLink)}>
+              오픈채팅 시작하기
             </Button>
           </BottomFixedBar>
         </>


### PR DESCRIPTION
## What's Changed? 
신고하기, 탈퇴하기 
- 성공, 에러에 따라서 toast 메세지 노출

오픈채팅 링크
- a link로 바로 이동되지 않고 컨펌 모달 노출 후 확인 시 이동

## Screenshots
<img width="991" alt="Screen Shot 2023-01-01 at 5 01 56 PM" src="https://user-images.githubusercontent.com/46391618/210164483-e9ce42e0-1715-4ac6-9630-e8ea521a9880.png">

<img width="853" alt="Screen Shot 2023-01-01 at 5 06 13 PM" src="https://user-images.githubusercontent.com/46391618/210164534-0f25db8f-e5b0-459a-87d2-269c2d764306.png">

## Related to any issues?
- ⛔️

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
