### PR TITLE
:bug: fix: 재능등록 탭 가로 스크롤 되지 않는 이슈 해결

### DIFF
--- a/src/components/profile/ProfileCategoryTagList.tsx
+++ b/src/components/profile/ProfileCategoryTagList.tsx
@@ -38,7 +38,7 @@ const ProfileCategoryTagList = ({ categoryKey, className }: ProfileCategoryTagLi
   };
 
   return (
-    <form className={`${className} px-[16px] py-[24.5px]`}>
+    <form className={`${className} px-[16px]`}>
       {isSuccess &&
         data.data.map(({ id, name, subCategories }: MidAndSubCategoriesProps) => {
           return (

--- a/src/components/talentRegister/TalentRegisterCategoryTabList.tsx
+++ b/src/components/talentRegister/TalentRegisterCategoryTabList.tsx
@@ -5,7 +5,15 @@ import TabList from '../common/TabList';
 const TalentRegisterCategoryTabList = () => {
   const { isLoading, data } = useGetCategory({ sort: 'main' });
 
-  return <>{!isLoading && <TabList categoryKey="mainCategory" list={data.data} />}</>;
+  return (
+    <>
+      {!isLoading && (
+        <div className="mb-24">
+          <TabList categoryKey="mainCategory" list={data.data} />
+        </div>
+      )}
+    </>
+  );
 };
 
 export default TalentRegisterCategoryTabList;

--- a/src/components/talentRegister/TalentRegisterCategoryTagList.tsx
+++ b/src/components/talentRegister/TalentRegisterCategoryTagList.tsx
@@ -32,8 +32,8 @@ const TalentRegisterCategoryTagList = ({ sort, className }: TalentRegisterProps)
   };
 
   return (
-    <form className={`${className} px-[16px] py-[24.5px]`}>
-      <div className="mt-[229.52px] h-[80vh]">
+    <form className={`${className} px-[16px]`}>
+      <div>
         {isSuccess &&
           data.data.map(({ id, name, subCategories }: MidAndSubCategoriesProps) => {
             return (

--- a/src/components/talentRegister/TalentRegisterFormThree.tsx
+++ b/src/components/talentRegister/TalentRegisterFormThree.tsx
@@ -67,7 +67,7 @@ const TalentRegisterFormThree = ({ className, sort }: TalentRegisterProps) => {
   const disabled = useTalentRegisterFormDisabled({ requiredTakenCategoryNumber: 1 });
 
   return (
-    <form className={`${className} px-[16px] py-[24.5px]`}>
+    <form className={`${className} px-[16px]`}>
       <TextSelectInput option={{ ...CATEGORY[sort], key: categoryKey }} />
       <TextTextarea option={EXPLANATION[sort]} />
       <Layout.FixedBottom>

--- a/src/pages/talent/register/exchange/category/index.tsx
+++ b/src/pages/talent/register/exchange/category/index.tsx
@@ -8,10 +8,8 @@ const sort = 'EXCHANGE';
 const TalentRegisterExchangeCategory = () => {
   return (
     <>
-      <div className="fixed top-0">
-        <TalentRegisterCategotyHeader sort={sort} />
-        <TalentRegisterCategoryTabList />
-      </div>
+      <TalentRegisterCategotyHeader sort={sort} />
+      <TalentRegisterCategoryTabList />
       <TalentRegisterCategoryTagList sort={sort} />
     </>
   );

--- a/src/pages/talent/register/share/category/index.tsx
+++ b/src/pages/talent/register/share/category/index.tsx
@@ -8,10 +8,8 @@ const sort = 'SHARE';
 const TalentRegisterShareCategory = () => {
   return (
     <>
-      <div className="fixed top-0">
-        <TalentRegisterCategotyHeader sort={sort} />
-        <TalentRegisterCategoryTabList />
-      </div>
+      <TalentRegisterCategotyHeader sort={sort} />
+      <TalentRegisterCategoryTabList />
       <TalentRegisterCategoryTagList sort={sort} />
     </>
   );


### PR DESCRIPTION
## What's Changed? 
재능등록 쪽 탭을 담고 있는 container div에 position: fixed 가 들어가있어서 발생한 문제로 보입니다
position:fixed 삭제하고, 삭제하고나니 padding 이 전부 수정되어야해서 Form, Tab, TagList 쪽 패딩 마진 수정하였습니다.

## Screenshots
<img width="529" alt="Screen Shot 2023-01-01 at 11 45 36 PM" src="https://user-images.githubusercontent.com/46391618/210174662-30eb63a0-4901-44fe-8813-bb3d8e1b5042.png">
<img width="473" alt="Screen Shot 2023-01-01 at 11 45 24 PM" src="https://user-images.githubusercontent.com/46391618/210174664-48aa6565-bad5-4d98-be47-8590ca9ceee9.png">


## Related to any issues?
- ⛔️

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
