### PR TITLE
:bug: fix: Move userInfoQuery to Layout

### DIFF
--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -2,10 +2,12 @@ import { useIsFetching } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import type { PropsWithChildren } from 'react';
 import { useEffect, useMemo } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
+import useUserInfoQuery from '@/hooks/queries/useUserInfoQuery';
 import useBottomSheet from '@/hooks/useBottomSheet';
-import { headerAtom, popupAtom, spinnerAtom, toastAtom } from '@/store/components/atoms';
+import { headerAtom, myInfoAtom, popupAtom, spinnerAtom, toastAtom } from '@/store/components/atoms';
+import type { UserInfo } from '@/typings/common';
 
 import BottomSheet from './BottomSheet';
 import BottomSheetOptions from './BottomSheetOptions';
@@ -28,6 +30,15 @@ const Layout = ({ children }: PropsWithChildren) => {
   const { isBottomSheetOpen, closeBottomSheet } = useBottomSheet();
 
   const isFetching = useIsFetching();
+
+  const { data: userData, isSuccess: userDataIsSuccess } = useUserInfoQuery();
+  const setMyInfo = useSetRecoilState<UserInfo | null>(myInfoAtom);
+
+  useEffect(() => {
+    if (!userDataIsSuccess) return;
+
+    setMyInfo(userData);
+  }, [userDataIsSuccess, userData, setMyInfo]);
 
   useEffect(() => {
     let timer = null;

--- a/src/pages/main.tsx
+++ b/src/pages/main.tsx
@@ -18,16 +18,12 @@ import { Layout, Typography } from '@/components/styles';
 import useCategoriesQuery from '@/hooks/queries/useCategoriesQuery';
 import useCustomPostsQuery from '@/hooks/queries/useCustomPostsQuery';
 import useInfinitePostsQuery from '@/hooks/queries/useInfinitePostsQuery';
-import useUserInfoQuery from '@/hooks/queries/useUserInfoQuery';
 import useBottomSheet from '@/hooks/useBottomSheet';
 import { bottomSheetActiveOptionAtom, midCategoryIdSelector, myInfoAtom } from '@/store/components';
-import type { UserInfo } from '@/typings/common';
 
 const Home: NextPage = () => {
   const { ref, inView } = useInView();
-
-  const { data: userData, isSuccess: userDataIsSuccess } = useUserInfoQuery();
-  const [myInfo, setMyInfo] = useRecoilState<UserInfo | null>(myInfoAtom);
+  const myInfo = useRecoilValue(myInfoAtom);
 
   const [activeMainCategoryId, setActiveCategoryId] = useState(0);
   const [activeSubCategoryId, setActiveSubCategoryId] = useState(0);
@@ -72,12 +68,6 @@ const Home: NextPage = () => {
   }, [isShare, activeMainCategoryId, activeMidCategoryId, activeSubCategoryId, refetch]);
 
   useEffect(() => {
-    if (!userDataIsSuccess) return;
-
-    setMyInfo(userData);
-  }, [userDataIsSuccess, userData, setMyInfo]);
-
-  useEffect(() => {
     const { id } = activeOption;
     if (typeof id === 'string') return;
 
@@ -106,7 +96,7 @@ const Home: NextPage = () => {
     <Layout.DefaultContainer>
       <Layout.DefaultPadding>
         <div className="mb-28">
-          {userDataIsSuccess && (
+          {myInfo && (
             <HomeHeader>
               <Typography.Title>
                 <span className="text-primary-blue">{myInfo?.nickname}</span> 님,

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -25,11 +25,6 @@ export default function Profile() {
     if (inView && isShowAllPosts) fetchNextPage();
   }, [inView, fetchNextPage, isShowAllPosts]);
 
-  // TODO: profile 페이지 새로고침 시 myInfo 가 null 로 초기화되는 이슈가 있음
-  // useEffect(() => {
-  //   console.log('myInfo', myInfo);
-  // }, [myInfo]);
-
   return (
     <main className="bg-bg-gray">
       {myInfo && (


### PR DESCRIPTION
## What's Changed? 
- userInfoQuery 호출, myInfo recoil 에 저장하는 로직을 Layout으로 이동합니다. 
- 프로필보기에서 새로고침시 데이터 없어서 화면이 보이지 않는 이슈를 해결합니다.
  
## Screenshots


## Related to any issues?
- ⛔️

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
