### PR TITLE
fix: Fix activeMidCategoryList condition error

### DIFF
--- a/src/pages/main.tsx
+++ b/src/pages/main.tsx
@@ -158,7 +158,7 @@ const Home: NextPage = () => {
           />
         </div>
       )}
-      {activeMidCategoryList.length && (
+      {activeMidCategoryList.length > 0 && (
         <MidCategoryTab
           mainCategoryName={getActiveCategory(activeMainCategoryId)?.name || ''}
           list={activeMidCategoryList || []}


### PR DESCRIPTION
## What's Changed? 
### 메인 화면 카테고리 부분에 `'0'`이 나오는 문제를 해결했어요
- `activeCategoryList.length` 조건 때문에 길이가 0 일때 0이 `return` 되는 문제를 해결했어요



## Related to any issues?
- ⛔️

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
