### PR TITLE
fix: Add meta data to prevent zoom

### DIFF
--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,4 +1,5 @@
 import { useIsFetching } from '@tanstack/react-query';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 import type { PropsWithChildren } from 'react';
 import { useEffect, useMemo } from 'react';
@@ -62,6 +63,9 @@ const Layout = ({ children }: PropsWithChildren) => {
 
   return (
     <>
+      <Head>
+        <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0" />
+      </Head>
       {headerValue && <Header {...headerValue} />}
       <main className={showGnb ? `pb-[82px]` : ''}>{children}</main>
       {popupValue?.isShowing && <Popup {...popupValue} />}


### PR DESCRIPTION
## What's Changed? 
### 앱에서 줌인/줌아웃 문제 해결을 위한 메타 데이터를 추가했어요.

```html
<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0" />
```

## Screenshots
![image](https://user-images.githubusercontent.com/79739512/211190286-9fbcc484-3c92-4aea-96f4-3338bba8b4bb.png)


## Related to any issues?
- ⛔️

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
