### PR TITLE
Fix: 메인페이지 맞춤 재능

### DIFF
--- a/src/components/common/CardCarousel.tsx
+++ b/src/components/common/CardCarousel.tsx
@@ -1,5 +1,6 @@
 /* doc: https://swiperjs.com/react */
 
+import Link from 'next/link';
 import styled from 'styled-components';
 import { Pagination } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -15,7 +16,9 @@ const CardCarousel = ({ list }: { list: CardInfo[] }) => {
       <Swiper pagination={true} modules={[Pagination]}>
         {list.map((item) => (
           <SwiperSlide key={uniqueId('carousel-slide')}>
-            <Card {...item} hideTakenTalents={true} />
+            <Link href={`/posts/${item.id}`}>
+              <Card {...item} hideTakenTalents={true} />
+            </Link>
           </SwiperSlide>
         ))}
       </Swiper>

--- a/src/hooks/queries/useCustomPostsQuery.ts
+++ b/src/hooks/queries/useCustomPostsQuery.ts
@@ -7,7 +7,6 @@ import type { CardInfo } from '@/typings/common';
 import { useAuth } from '../useAuth';
 
 interface CustomPostsQueryParams {
-  subCategoryId: number;
   page: number;
   size: number;
 }
@@ -19,12 +18,11 @@ interface CustomPostsData {
 const useCustomPostsQuery = (params: CustomPostsQueryParams) => {
   const { isLogin } = useAuth();
 
-  const fetchCustomPosts = async ({ subCategoryId, page, size }: CustomPostsQueryParams) => {
+  const fetchCustomPosts = async ({ page, size }: CustomPostsQueryParams) => {
     const {
       data: { data },
     } = await axiosClient.get<ServerResponse<CustomPostsData>>(`/posts/custom`, {
       params: {
-        subCategoryId,
         page,
         size,
       },

--- a/src/pages/main.tsx
+++ b/src/pages/main.tsx
@@ -38,7 +38,6 @@ const Home: NextPage = () => {
   const queryClient = useQueryClient();
 
   const { data: customPostsData, isSuccess: customPostsIsSuccess } = useCustomPostsQuery({
-    subCategoryId: 1,
     page: 0,
     size: 5,
   });


### PR DESCRIPTION
## What's Changed? 
- 맞춤 재능 조회시 subCategory를 1로 고정해두고 호출 [QA 이슈 링크](https://www.notion.so/depromeet/subCategory-1-3b15325571b64c1c896022918348a07d)
- 맞춤 재능 카드 클릭시 이동하지 않음

## Screenshots

<img width="609" alt="Screen Shot 2023-01-08 at 9 22 33 PM" src="https://user-images.githubusercontent.com/46391618/211195882-5f4cdec7-9027-4647-bcef-af201d7deba6.png">

## Related to any issues?
- ⛔️


## Dependency Changes
- ⛔️

## Test Code
- ⛔️
