### PR TITLE
fix: Fix custom post routing issue

### DIFF
--- a/src/components/common/CardCarousel.tsx
+++ b/src/components/common/CardCarousel.tsx
@@ -10,13 +10,17 @@ import type { CardInfo } from '@/typings/common';
 
 import Card from './Card';
 
-const CardCarousel = ({ list }: { list: CardInfo[] }) => {
+interface CardCarouselInfo extends CardInfo {
+  postId?: number;
+}
+
+const CardCarousel = ({ list }: { list: CardCarouselInfo[] }) => {
   return (
     <SwiperWrapper>
       <Swiper pagination={true} modules={[Pagination]}>
         {list.map((item) => (
           <SwiperSlide key={uniqueId('carousel-slide')}>
-            <Link href={`/posts/${item.id}`}>
+            <Link href={`/posts/${item.postId}`}>
               <Card {...item} hideTakenTalents={true} />
             </Link>
           </SwiperSlide>


### PR DESCRIPTION
## What's Changed? 
### 커스텀 포스터 클릭시 `undefined`로 라우팅 되는 문제를 해결했어요
- 명세서에 있는 `postId`로 연결되어야 하는데 id로 연결되어 오류가 발생했어요.
- 커스텀 포스트와 일반 포스트 `response` 값이 다른거 같아 새로운 타이핑 방식이 필요해보여요


## Screenshots


## Related to any issues?
- ⛔️

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
