### PR TITLE
fix: Fix post remove action error

### DIFF
--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import BottomFixedBar from '@/components/common/BottomFixedBar';
@@ -30,7 +30,7 @@ const PostDetail = () => {
 
   const [reportReason, setReportReason] = useState<string>('');
   const [isMyPost, setIsMyPost] = useState(false);
-  const activeOption = useRecoilValue(bottomSheetActiveOptionAtom);
+  const [activeOption, setActiveOption] = useRecoilState(bottomSheetActiveOptionAtom);
   const myInfo = useRecoilValue(myInfoAtom);
 
   const { data: postData, isSuccess: postIsSuccess, refetch } = usePostQuery(postId);
@@ -60,25 +60,25 @@ const PostDetail = () => {
     });
   }, [setPopup, reportPostMutate, postId, reportReason]);
 
-  const handleKakaoLinkPopup = useCallback(
-    (link: string) => {
-      const openExternalLink = (link: string) => {
-        if (!window) return;
+  // const handleKakaoLinkPopup = useCallback(
+  //   (link: string) => {
+  //     const openExternalLink = (link: string) => {
+  //       if (!window) return;
 
-        window.open(`//${link}`, '_blank');
-      };
+  //       window.open(`//${link}`, '_blank');
+  //     };
 
-      setPopup({
-        isShowing: true,
-        title: '카카오톡 오픈채팅으로 이동됩니다',
-        content: '오픈채팅 시, 상대방에게 <br />불쾌감을 주는 언어 사용을 지양해주세요.',
-        onConfirm: () => openExternalLink(link),
-        confirmText: '이동하기',
-        cancelText: '취소',
-      });
-    },
-    [setPopup],
-  );
+  //     setPopup({
+  //       isShowing: true,
+  //       title: '카카오톡 오픈채팅으로 이동됩니다',
+  //       content: '오픈채팅 시, 상대방에게 <br />불쾌감을 주는 언어 사용을 지양해주세요.',
+  //       onConfirm: () => openExternalLink(link),
+  //       confirmText: '이동하기',
+  //       cancelText: '취소',
+  //     });
+  //   },
+  //   [setPopup],
+  // );
 
   useEffect(() => {
     if (!postIsSuccess) return;
@@ -92,11 +92,14 @@ const PostDetail = () => {
   }, [myInfo?.memberId, postData?.memberId, router]);
 
   useEffect(() => {
-    if (activeOption.id === 'DELETE') postDeleteMutate();
+    if (activeOption.id === 'DELETE') {
+      postDeleteMutate();
+      setActiveOption({ id: 0, label: '' });
+    }
     if (activeOption.id === 'REPORT') {
       handleReportPopup();
     }
-  }, [activeOption, postDeleteMutate, reportPostMutate, handleReportPopup]);
+  }, [activeOption, postDeleteMutate, reportPostMutate, handleReportPopup, setActiveOption]);
 
   usePopupWithBlock();
 
@@ -112,7 +115,9 @@ const PostDetail = () => {
   }, [reportPostIsSuccess, router]);
 
   useEffect(() => {
-    if (postDeleteIsSuccess) {
+    if (postDeleteIsSuccess && router.query.new === 'true') {
+      router.push('/main');
+    } else if (postDeleteIsSuccess) {
       router.back();
     }
   }, [postDeleteIsSuccess, router]);


### PR DESCRIPTION
## What's Changed? 
### 게시글 삭제이후 다른 게시글 클릭시 계속 `remove` `mutation`이 발생하는 오류를 해결했어요.
- 처음 게시글 삭제 이후 `bottomSheetActiveOptionAtom`에 `Delete`가 보존되어 문제가 발생했어요.
- `mutate` 요청이후 해당 상태를 초기화하게 로직을 추가했어요.

### 새로 생성된 글을 삭제할 때 게시글 생성으로 라우팅 되는 문제를 해결했어요.
- 처음 게시글 생성 이후 게시글을 삭제할 때 `router.back()`으로 인해 다시 게시글 등록으로 돌아가는 문제가 발생했어요.
- `router.query.new`로 체크하는 조건을 추가해 문제를 해결했어요. 


## Screenshots


## Related to any issues?
- ⛔️

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
