### PR TITLE
fix: Fix profile edit, profile index popup issue

### DIFF
--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -27,7 +27,7 @@ const ProfileView = ({ isMe = false, userInfo }: { isMe: boolean; userInfo: User
   }, [inView, fetchNextPage, isShowAllPosts]);
 
   const onClickBack = () => {
-    router.query.new ? router.push('/main') : router.back();
+    router.query.new || isMe ? router.push('/main') : router.back();
   };
 
   return (

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -126,7 +126,7 @@ const ProfileView = ({ isMe = false, userInfo }: { isMe: boolean; userInfo: User
       </section>
       <section className="bg-white border-t border-gray-100 pt-[28px] pb-[36px] px-[16px]">
         <h2 className="text-t3 mb-[8px]">{isMe ? `내가 쓴 글` : `${userInfo.nickname}님이 쓴 글`}</h2>
-        {postsIsSuccess ? (
+        {postsIsSuccess && posts.length > 0 ? (
           <CardContainer>
             {posts.map((item) => {
               return (

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -3,11 +3,14 @@ import { useRecoilState } from 'recoil';
 
 import ProfileView from '@/components/profile/ProfileView';
 import useUserInfoQuery from '@/hooks/queries/useUserInfoQuery';
+import { usePopupWithBlock } from '@/hooks/usePopupWithBlock';
 import { myInfoAtom } from '@/store/components';
 
 export default function ProfileMe() {
   const [userInfo, setUserInfo] = useRecoilState(myInfoAtom);
   const { data, isSuccess } = useUserInfoQuery();
+
+  usePopupWithBlock(undefined);
 
   useEffect(() => {
     if (isSuccess) {


### PR DESCRIPTION
## What's Changed? 
### 프로필 카테고리 편집 -> 저장 완료 이후 뒤로가기 클릭시 팝업이 발생하는 오류를 해결했어요.
- 아래와 같이 프로필 화면에서 뒤로가기시 편집화면에서 나오는 팝업이 나오는 오류가 발생했어요.
- `usePopupWithBlock(undefined)`를 이용하여 프로필 화면에서 해당 팝업이 나오지 않게 문제를 해결했어요.
<img width="235" alt="image" src="https://user-images.githubusercontent.com/79739512/211274350-068a4d2e-ecf3-4688-a3dc-ca796e44f5d6.png">

### 프로필 화면에서 게시글이 없을시 `EmptyCard`가 나오지 않던 오류를 해결했어요.
<img width="293" alt="image" src="https://user-images.githubusercontent.com/79739512/211274710-ca031994-a2cd-49e9-8e90-9a7e94604b71.png">


## Screenshots


## Related to any issues?
- ⛔️

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
