### PR TITLE
Fix: tab list 이슈 수정

### DIFF
--- a/src/components/common/ClickTag.tsx
+++ b/src/components/common/ClickTag.tsx
@@ -1,4 +1,4 @@
-import useTab from '@/hooks/useTab';
+import useTag from '@/hooks/useTag';
 
 import { XIcon } from '../icons/XIcon';
 
@@ -12,7 +12,7 @@ interface ClickTagProps {
 }
 
 const ClickTag = ({ categoryKey, id, name, sort, isDelete = false, className }: ClickTagProps) => {
-  const { onClick, clicked } = useTab({
+  const { onClick, clicked } = useTag({
     key: categoryKey,
     id,
     selectingNumber: categoryKey === 'subCategoryId' ? 1 : 5,

--- a/src/components/main/SubCategoryFilter.tsx
+++ b/src/components/main/SubCategoryFilter.tsx
@@ -27,7 +27,7 @@ const SubCategoryFilter = ({
     <FilterContainer>
       {isSubFilterVisible && (
         <SubFilterDropdown onClick={handleSubCategory}>
-          {activeOption ? activeOption.label : '소분류'}
+          {activeOption.label ? activeOption.label : '소분류'}
           <ArrowDownIcon />
         </SubFilterDropdown>
       )}

--- a/src/components/profile/ProfileCategoryTagList.tsx
+++ b/src/components/profile/ProfileCategoryTagList.tsx
@@ -19,7 +19,7 @@ interface ProfileCategoryTagListProps {
 
 const ProfileCategoryTagList = ({ categoryKey, className }: ProfileCategoryTagListProps) => {
   const { id } = useRecoilValue(categoryAtomFamily('mainCategory'));
-  const selectedTab = useRecoilValue(tabAtomFamily(categoryKey));
+  const selectedTag = useRecoilValue(tabAtomFamily(categoryKey));
   const {
     midCategoryQuery: { isSuccess, data },
   } = useCategoriesQuery({
@@ -51,7 +51,7 @@ const ProfileCategoryTagList = ({ categoryKey, className }: ProfileCategoryTagLi
         })}
       <TalentRegisterCategoryBottomSheet sort={'EXCHANGE'} categoryKey={categoryKey}>
         <Link href={href} className="block">
-          <Button type="button" onClick={onClick} disabled={selectedTab.length === 0} className="w-full">
+          <Button type="button" onClick={onClick} disabled={selectedTag.length === 0} className="w-full">
             선택 완료
           </Button>
         </Link>

--- a/src/components/profile/ProfileCategoryTagList.tsx
+++ b/src/components/profile/ProfileCategoryTagList.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
 
 import useCategoriesQuery from '@/hooks/queries/useCategoriesQuery';
-import { mainCategoryAtom, tabAtomFamily } from '@/store/components';
+import { categoryAtomFamily, tabAtomFamily } from '@/store/components';
 import type { MidCategory } from '@/typings/common';
 
 import Button from '../common/Button';
@@ -18,7 +18,7 @@ interface ProfileCategoryTagListProps {
 }
 
 const ProfileCategoryTagList = ({ categoryKey, className }: ProfileCategoryTagListProps) => {
-  const [{ id }] = useRecoilValue(mainCategoryAtom);
+  const { id } = useRecoilValue(categoryAtomFamily('mainCategory'));
   const selectedTab = useRecoilValue(tabAtomFamily(categoryKey));
   const {
     midCategoryQuery: { isSuccess, data },

--- a/src/components/profile/ProfileCategoryTagList.tsx
+++ b/src/components/profile/ProfileCategoryTagList.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
 
 import useCategoriesQuery from '@/hooks/queries/useCategoriesQuery';
-import { tabAtomFamily } from '@/store/components';
+import { mainCategoryAtom, tabAtomFamily } from '@/store/components';
 import type { MidCategory } from '@/typings/common';
 
 import Button from '../common/Button';
@@ -18,7 +18,7 @@ interface ProfileCategoryTagListProps {
 }
 
 const ProfileCategoryTagList = ({ categoryKey, className }: ProfileCategoryTagListProps) => {
-  const [{ id }] = useRecoilValue(tabAtomFamily('mainCategory'));
+  const [{ id }] = useRecoilValue(mainCategoryAtom);
   const selectedTab = useRecoilValue(tabAtomFamily(categoryKey));
   const {
     midCategoryQuery: { isSuccess, data },

--- a/src/components/talentRegister/TalentRegisterCategoryTagList.tsx
+++ b/src/components/talentRegister/TalentRegisterCategoryTagList.tsx
@@ -4,7 +4,7 @@ import { useRecoilValue } from 'recoil';
 import type { TalentRegisterProps } from '@/constants/talentRegister/talentRegisterType';
 import useCategoriesQuery from '@/hooks/queries/useCategoriesQuery';
 import { SetTalnetRegisterCategorySelectInputKey } from '@/lib/utils';
-import { tabAtomFamily } from '@/store/components';
+import { mainCategoryAtom, tabAtomFamily } from '@/store/components';
 import type { MidCategory } from '@/typings/common';
 
 import Button from '../common/Button';
@@ -12,7 +12,8 @@ import ClickTagList from '../common/ClickTagList';
 import TalentRegisterCategoryBottomSheet from './TalentRegisterCategoryBottomSheet';
 
 const TalentRegisterCategoryTagList = ({ sort, className }: TalentRegisterProps) => {
-  const [{ id }] = useRecoilValue(tabAtomFamily('mainCategory'));
+  const [{ id }] = useRecoilValue(mainCategoryAtom);
+
   const categoryKey = SetTalnetRegisterCategorySelectInputKey();
   const selectedTab = useRecoilValue(tabAtomFamily(categoryKey));
 

--- a/src/components/talentRegister/TalentRegisterCategoryTagList.tsx
+++ b/src/components/talentRegister/TalentRegisterCategoryTagList.tsx
@@ -4,7 +4,7 @@ import { useRecoilValue } from 'recoil';
 import type { TalentRegisterProps } from '@/constants/talentRegister/talentRegisterType';
 import useCategoriesQuery from '@/hooks/queries/useCategoriesQuery';
 import { SetTalnetRegisterCategorySelectInputKey } from '@/lib/utils';
-import { mainCategoryAtom, tabAtomFamily } from '@/store/components';
+import { categoryAtomFamily, tabAtomFamily } from '@/store/components';
 import type { MidCategory } from '@/typings/common';
 
 import Button from '../common/Button';
@@ -12,7 +12,7 @@ import ClickTagList from '../common/ClickTagList';
 import TalentRegisterCategoryBottomSheet from './TalentRegisterCategoryBottomSheet';
 
 const TalentRegisterCategoryTagList = ({ sort, className }: TalentRegisterProps) => {
-  const [{ id }] = useRecoilValue(mainCategoryAtom);
+  const { id } = useRecoilValue(categoryAtomFamily('mainCategory'));
 
   const categoryKey = SetTalnetRegisterCategorySelectInputKey();
   const selectedTab = useRecoilValue(tabAtomFamily(categoryKey));
@@ -38,7 +38,7 @@ const TalentRegisterCategoryTagList = ({ sort, className }: TalentRegisterProps)
               <div key={id}>
                 <span className="text-t4 text-gray-600">{name}</span>
                 <ClickTagList
-                  key={id}
+                  key={`taglist-${id}`}
                   categoryKey={categoryKey}
                   list={subCategories}
                   sort={sort}

--- a/src/components/talentRegister/TalentRegisterCategoryTagList.tsx
+++ b/src/components/talentRegister/TalentRegisterCategoryTagList.tsx
@@ -15,7 +15,7 @@ const TalentRegisterCategoryTagList = ({ sort, className }: TalentRegisterProps)
   const { id } = useRecoilValue(categoryAtomFamily('mainCategory'));
 
   const categoryKey = SetTalnetRegisterCategorySelectInputKey();
-  const selectedTab = useRecoilValue(tabAtomFamily(categoryKey));
+  const selectedTag = useRecoilValue(tabAtomFamily(categoryKey));
 
   const {
     midCategoryQuery: { isSuccess, data },
@@ -50,7 +50,7 @@ const TalentRegisterCategoryTagList = ({ sort, className }: TalentRegisterProps)
       </div>
       <TalentRegisterCategoryBottomSheet sort={sort} categoryKey={categoryKey}>
         <Link href={href} className="block">
-          <Button type="button" onClick={onClick} disabled={selectedTab.length === 0} className="w-full">
+          <Button type="button" onClick={onClick} disabled={selectedTag.length === 0} className="w-full">
             선택 완료
           </Button>
         </Link>

--- a/src/hooks/useTab.ts
+++ b/src/hooks/useTab.ts
@@ -1,23 +1,15 @@
 import type React from 'react';
 import { useCallback, useEffect, useState } from 'react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 
-import { popupAtom, tabAtomFamily } from '@/store/components';
+import { categoryAtomFamily } from '@/store/components';
 import type { TabProps } from '@/store/components/types';
-import type { PopupProps } from '@/typings/common';
 
 // TODO: 해당 카테고리 전체에 해당하는 값을 id=999로 사용함. 이후 전체를 의미하는 값을 따로 가지도록 변경 필요
 interface UseTabProps {
   key: string;
   id: number;
-  selectingNumber?: number;
 }
-
-const POPUP_INFO = {
-  isShowing: true,
-  title: '최대 5개까지 선택할 수 있어요',
-  confirmText: '확인',
-};
 
 /** TODO: 추후 수정 필요
  * 로직을 recoil 안에다 작성하려다가 밖으로 빼서 작성하였는데 key 관리 관련해서 문제가 있습니다.
@@ -25,46 +17,22 @@ const POPUP_INFO = {
  */
 
 // TODO: useTab example 추가하기
-const useTab = ({ key, id, selectingNumber = 1 }: UseTabProps) => {
-  const [selectedTab, setSelectedTab] = useRecoilState<TabProps[]>(tabAtomFamily(key));
+const useTab = ({ key, id }: UseTabProps) => {
+  const [selectedTab, setSelectedTab] = useRecoilState<TabProps>(categoryAtomFamily(key));
   const [clicked, setClicked] = useState(false);
-  //* TODO: 팝업 관련 로직 수정 필요
-  const setPopup = useSetRecoilState<PopupProps | null>(popupAtom);
 
   useEffect(() => {
-    if (selectedTab.some((tab) => tab.id === id)) {
-      setClicked(true);
-    } else {
-      setClicked(false);
-    }
+    selectedTab.id === id ? setClicked(true) : setClicked(false);
   }, [id, selectedTab]);
 
   const onClick = useCallback(
     (event: React.MouseEvent) => {
-      const { id: clickedTabId, innerHTML: clickedTabName } = event.currentTarget;
-      const clickedTab = { id: Number(clickedTabId), name: clickedTabName };
-
-      const isClickedTab = selectedTab.some((tab) => tab.id === Number(clickedTabId));
-      const isMoreSelect = selectedTab.length < selectingNumber;
-      const isPopup = selectingNumber === 5 && selectedTab.length === 5 && !isClickedTab;
-
-      if (isPopup) {
-        setPopup(POPUP_INFO);
-      }
-
-      if (!isClickedTab && isMoreSelect) {
-        setSelectedTab((prev) => [...prev, clickedTab]);
-      } else {
-        setSelectedTab(() => {
-          return selectingNumber === 1
-            ? selectedTab[0].id === Number(clickedTabId)
-              ? selectedTab.filter((tab) => tab.id !== Number(clickedTabId))
-              : [clickedTab]
-            : selectedTab.filter((tab) => tab.id !== Number(clickedTabId));
-        });
-      }
+      const { id, innerHTML } = event.currentTarget;
+      setSelectedTab(() => {
+        return { id: Number(id), name: innerHTML };
+      });
     },
-    [selectedTab, selectingNumber, setPopup, setSelectedTab],
+    [setSelectedTab],
   );
 
   return { onClick, clicked };

--- a/src/hooks/useTag.ts
+++ b/src/hooks/useTag.ts
@@ -1,0 +1,72 @@
+import type React from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+
+import { popupAtom, tabAtomFamily } from '@/store/components';
+import type { TagProps } from '@/store/components/types';
+import type { PopupProps } from '@/typings/common';
+
+// TODO: 해당 카테고리 전체에 해당하는 값을 id=999로 사용함. 이후 전체를 의미하는 값을 따로 가지도록 변경 필요
+interface UseTagProps {
+  key: string;
+  id: number;
+  selectingNumber?: number;
+}
+
+const POPUP_INFO = {
+  isShowing: true,
+  title: '최대 5개까지 선택할 수 있어요',
+  confirmText: '확인',
+};
+
+/** TODO: 추후 수정 필요
+ * 로직을 recoil 안에다 작성하려다가 밖으로 빼서 작성하였는데 key 관리 관련해서 문제가 있습니다.
+ * 추후에 해당 로직을 recoil 안에다 작성하는 것이 유지보수 측면에서 유리할 듯 합니다.
+ */
+
+const useTag = ({ key, id, selectingNumber = 1 }: UseTagProps) => {
+  const [selectedTag, setSelectedTag] = useRecoilState<TagProps[]>(tabAtomFamily(key));
+  const [clicked, setClicked] = useState(false);
+  //* TODO: 팝업 관련 로직 수정 필요
+  const setPopup = useSetRecoilState<PopupProps | null>(popupAtom);
+
+  useEffect(() => {
+    if (selectedTag.some((tab) => tab.id === id)) {
+      setClicked(true);
+    } else {
+      setClicked(false);
+    }
+  }, [id, selectedTag]);
+
+  const onClick = useCallback(
+    (event: React.MouseEvent) => {
+      const { id: clickedTagId, innerHTML: clickedTagName } = event.currentTarget;
+      const clickedTag = { id: Number(clickedTagId), name: clickedTagName };
+
+      const isClickedTag = selectedTag.some((tab) => tab.id === Number(clickedTagId));
+      const isMoreSelect = selectedTag.length < selectingNumber;
+      const isPopup = selectingNumber === 5 && selectedTag.length === 5 && !isClickedTag;
+
+      if (isPopup) {
+        setPopup(POPUP_INFO);
+      }
+
+      if (!isClickedTag && isMoreSelect) {
+        setSelectedTag((prev) => [...prev, clickedTag]);
+      } else {
+        setSelectedTag(() => {
+          return selectingNumber === 1
+            ? selectedTag[0].id === Number(clickedTagId)
+              ? selectedTag.filter((tab) => tab.id !== Number(clickedTagId))
+              : [clickedTag]
+            : selectedTag.filter((tab) => tab.id !== Number(clickedTagId));
+        });
+      }
+    },
+    [selectedTag, selectingNumber, setPopup, setSelectedTag],
+  );
+
+  return { onClick, clicked };
+};
+
+export default useTag;

--- a/src/hooks/useTag.ts
+++ b/src/hooks/useTag.ts
@@ -6,7 +6,6 @@ import { popupAtom, tabAtomFamily } from '@/store/components';
 import type { TagProps } from '@/store/components/types';
 import type { PopupProps } from '@/typings/common';
 
-// TODO: 해당 카테고리 전체에 해당하는 값을 id=999로 사용함. 이후 전체를 의미하는 값을 따로 가지도록 변경 필요
 interface UseTagProps {
   key: string;
   id: number;

--- a/src/pages/main.tsx
+++ b/src/pages/main.tsx
@@ -19,7 +19,7 @@ import useCategoriesQuery from '@/hooks/queries/useCategoriesQuery';
 import useCustomPostsQuery from '@/hooks/queries/useCustomPostsQuery';
 import useInfinitePostsQuery from '@/hooks/queries/useInfinitePostsQuery';
 import useBottomSheet from '@/hooks/useBottomSheet';
-import { bottomSheetActiveOptionAtom, midCategoryIdSelector, myInfoAtom, tabAtomFamily } from '@/store/components';
+import { bottomSheetActiveOptionAtom, categoryAtomFamily, midCategoryIdSelector, myInfoAtom } from '@/store/components';
 import type { MidCategory } from '@/typings/common';
 
 const Home: NextPage = () => {
@@ -30,7 +30,7 @@ const Home: NextPage = () => {
   const [activeMidCategoryList, setActiveMidCategoryList] = useState<MidCategory[]>([]);
   const [activeSubCategoryId, setActiveSubCategoryId] = useState(0);
 
-  const setActiveMidCategory = useSetRecoilState(tabAtomFamily('midCategory'));
+  const setActiveMidCategory = useSetRecoilState(categoryAtomFamily('midCategory'));
   const activeMidCategoryId = useRecoilValue(midCategoryIdSelector);
   const activeOption = useRecoilValue(bottomSheetActiveOptionAtom);
   const [isShare, handleIsShare] = useState(false);
@@ -71,7 +71,7 @@ const Home: NextPage = () => {
 
   useEffect(() => {
     if (!activeMainCategoryId) return;
-    setActiveMidCategory([{ id: 0, name: '전체' }]);
+    setActiveMidCategory({ id: 0, name: '전체' });
 
     const list = getActiveCategory(activeMainCategoryId)?.midCategories;
 

--- a/src/store/components/atoms.ts
+++ b/src/store/components/atoms.ts
@@ -3,25 +3,32 @@ import { atom, atomFamily, selector } from 'recoil';
 import type { Radio } from '@/hooks/useRadioGroup';
 import type { HeaderProps, Option, PopupProps, UserInfo } from '@/typings/common';
 
-import type { TabProps, TalentRegisterInputInfo } from './types';
+import type { TagProps, TalentRegisterInputInfo } from './types';
 
 const loginStateAtom = atom({
   key: 'loginState',
   default: false,
 });
 
-const mainCategoryAtom = atom({
+const categoryAtomFamily = atomFamily({
   key: 'mainCategory',
-  default: [{ id: 1, name: '' }],
+  default: (inputKey) => {
+    switch (inputKey) {
+      case 'mainCategory':
+        return { id: 1, name: '' };
+      case 'midCategory':
+        return { id: 0, name: '전체' };
+      default:
+        return { id: 0, name: '' };
+    }
+  },
 });
 
-// TODO: tabAtom의 경우 key를 찾기 쉽지 않아 key 관리를 위한 좋은 방법이 필요합니다.
-const tabAtomFamily = atomFamily<TabProps[], string>({
+// TODO: tabAtomFamily 사용 개선
+const tabAtomFamily = atomFamily<TagProps[], string>({
   key: 'tab',
   default: (inputKey) => {
     switch (inputKey) {
-      case 'midCategory':
-        return [{ id: 0, name: '전체' }];
       default:
         return [];
     }
@@ -31,9 +38,9 @@ const tabAtomFamily = atomFamily<TabProps[], string>({
 const midCategoryIdSelector = selector<number>({
   key: 'activeMidCategoryId',
   get: ({ get }) => {
-    const midCategoryList = get(tabAtomFamily('midCategory'));
+    const midCategory = get(categoryAtomFamily('midCategory'));
 
-    return midCategoryList[0]?.id || 0;
+    return midCategory.id || 0;
   },
 });
 
@@ -138,9 +145,9 @@ export {
   bottomSheetActiveOptionAtom,
   bottomSheetAtom,
   bottomSheetOptionsAtom,
+  categoryAtomFamily,
   headerAtom,
   loginStateAtom,
-  mainCategoryAtom,
   midCategoryIdSelector,
   myInfoAtom,
   popupAtom,

--- a/src/store/components/atoms.ts
+++ b/src/store/components/atoms.ts
@@ -10,13 +10,16 @@ const loginStateAtom = atom({
   default: false,
 });
 
+const mainCategoryAtom = atom({
+  key: 'mainCategory',
+  default: [{ id: 1, name: '' }],
+});
+
 // TODO: tabAtom의 경우 key를 찾기 쉽지 않아 key 관리를 위한 좋은 방법이 필요합니다.
 const tabAtomFamily = atomFamily<TabProps[], string>({
   key: 'tab',
   default: (inputKey) => {
     switch (inputKey) {
-      case 'mainCategory':
-        return [{ id: 1, name: '' }];
       case 'midCategory':
         return [{ id: 0, name: '전체' }];
       default:
@@ -137,6 +140,7 @@ export {
   bottomSheetOptionsAtom,
   headerAtom,
   loginStateAtom,
+  mainCategoryAtom,
   midCategoryIdSelector,
   myInfoAtom,
   popupAtom,


### PR DESCRIPTION
## What's Changed? 
### useTab, useTag 분리
- 아래 이슈들을 해결하기 위해 리팩토링 + 버그 수정
### categoryAtomFamily 생성
- tabAtomFamily 와 categoryTab 로직을 분리하여 사용하기 위해 별도의 atom을 생성했습니다. 
###  Tab 두번 클릭 시  id undefined에러, 탭 선택 해제되는 이슈 해결
- 기존에 등록 카테고리 화면에서 동일 화면에서 tabAtomFamily가 tagList와 selectedTab 에 동시에 사용되어 id of undefined 이슈가 발생한것으로 보입니다. 
### 소분류 bottomSheet 이슈 해결
- selectedTab 의 기본 값을 array -> object 로 수정하면서, activeMidCategoryId selector가 정상적으로 동작하고, 소분류 bottomSheet 가 초기화 됩니다. 

## Screenshots


## Related to any issues?
- 탭 두번 클릭시 id undefined 이슈
- 탭 선택시 선택 해제됨 이슈
- 중분류 선택이 바뀌어도 소분류 bottomSheet 초기화 안됨 이슈

## Dependency Changes
- ⛔️

## Test Code
- ⛔️
